### PR TITLE
Fix oldTerritory coordinate order

### DIFF
--- a/lib/presentation/widgets/prism_game_widgets/hex_board.dart
+++ b/lib/presentation/widgets/prism_game_widgets/hex_board.dart
@@ -187,7 +187,7 @@ class _HexPainter extends CustomPainter {
         canvas.drawPath(path, stroke);
 
         // contorno do território anterior
-        if (oldTerritory.contains(Point(r, c))) {
+        if (oldTerritory.contains(Point(c, r))) {
           canvas.drawPath(path, borderOld);
         }
 


### PR DESCRIPTION
## Summary
- fix territory check coordinates when painting hex board

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840612653ec8321b11e6f5141bc26e6