### PR TITLE
Add background to Tango board

### DIFF
--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -93,8 +93,15 @@ class TangoBoardPage extends StatelessWidget {
                     final double tileSize =
                         (constraints.maxWidth - totalSpacing) / n;
 
-                    return Stack(
-                      children: [
+                    return Container(
+                      decoration: const BoxDecoration(
+                        image: DecorationImage(
+                          image: AssetImage('assets/images/ui/bg_gradient.png'),
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      child: Stack(
+                        children: [
                         // 1) Grid de tiles
                         GridView.builder(
                           physics: const NeverScrollableScrollPhysics(),
@@ -185,9 +192,10 @@ class TangoBoardPage extends StatelessWidget {
                           }
                         }).toList(),
                       ],
-                    );
-                  },
-                );
+                    ),
+                  );
+                },
+              );
               }),
             ),
           ),


### PR DESCRIPTION
## Summary
- update Tango board page to draw a gradient background using `assets/images/ui/bg_gradient.png`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840626f78808321a3d35f827547c6e1