### PR TITLE
Add background to Tango board

### DIFF
--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -27,9 +27,15 @@ class TangoBoardPage extends StatelessWidget {
           ),
         ],
       ),
-      backgroundColor: const Color(0xFF0D0D0D),
-      body: SafeArea(
-        child: Column(
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
           children: [
             SizedBox(height: 16),
             Obx( () {
@@ -185,9 +191,10 @@ class TangoBoardPage extends StatelessWidget {
                           }
                         }).toList(),
                       ],
-                    );
-                  },
-                );
+                    ),
+                  );
+                },
+              );
               }),
             ),
           ),


### PR DESCRIPTION
## Summary
- update Tango board to place gradient wallpaper on the scaffold instead of the grid

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840626f78808321a3d35f827547c6e1