### PR TITLE
Add JSON map import

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'firebase_options.dart';
 import 'presentation/pages/general_pages/leaderboard_page.dart';
 import 'presentation/pages/general_pages/settings_page.dart';
 import 'presentation/pages/general_pages/full_mode_page.dart';
+import 'presentation/pages/general_pages/import_map_page.dart';
 import 'presentation/pages/tango_game/tango_board_controller.dart' show TangoBoardController;
 import 'presentation/pages/tango_game/tango_board_page.dart';
 
@@ -47,6 +48,7 @@ class Prisma24App extends StatelessWidget {
         '/rank':  (_) => const LeaderboardPage(),
         '/settings': (_) => const SettingsPage(),
         '/tango': (_) => TangoBoardPage(),
+        '/import_map': (_) => const ImportMapPage(),
 
       },
     );

--- a/lib/presentation/pages/general_pages/home_page.dart
+++ b/lib/presentation/pages/general_pages/home_page.dart
@@ -69,6 +69,12 @@ class HomePage extends StatelessWidget {
                 icon: Icons.settings,
                 onTap: () => Navigator.pushNamed(context, '/settings'),
               ),
+              _MenuButton(
+                color: Colors.cyan,
+                label: 'Importar mapas',
+                icon: Icons.upload_file,
+                onTap: () => Navigator.pushNamed(context, '/import_map'),
+              ),
                 _MenuButton(
                 color: Colors.red,
                 label: 'Sair',

--- a/lib/presentation/pages/general_pages/import_map_page.dart
+++ b/lib/presentation/pages/general_pages/import_map_page.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:file_picker/file_picker.dart';
+
+class ImportMapPage extends StatefulWidget {
+  const ImportMapPage({super.key});
+
+  @override
+  State<ImportMapPage> createState() => _ImportMapPageState();
+}
+
+class _ImportMapPageState extends State<ImportMapPage> {
+  String? _status;
+
+  Future<void> _pickAndUpload() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
+      if (result == null || result.files.isEmpty) return;
+      final path = result.files.single.path;
+      if (path == null) return;
+      final text = await File(path).readAsString();
+      final data = json.decode(text);
+      await FirebaseFirestore.instance.collection('full_mode_maps').add(data);
+      setState(() => _status = 'Mapa enviado com sucesso!');
+    } catch (e) {
+      setState(() => _status = 'Erro ao enviar mapa: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Importar mapa')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _pickAndUpload,
+              child: const Text('Selecionar JSON'),
+            ),
+            if (_status != null)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  _status!,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   shared_preferences: 2.5.3
   package_info_plus: ^8.3.0
   get: ^4.6.5
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add ImportMapPage for uploading map JSON files to Firestore
- expose ImportMapPage route in app
- add button on HomePage to import maps
- include file_picker dependency for selecting files

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840716d52048321b2a2452bae24ecff