### PR TITLE
Implement Nonogram board

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,9 @@ import 'presentation/pages/general_pages/full_mode_page.dart';
 import 'presentation/pages/general_pages/add_phase_page.dart';
 import 'presentation/pages/tango_game/tango_board_controller.dart' show TangoBoardController;
 import 'presentation/pages/tango_game/tango_board_page.dart';
+import 'presentation/pages/nonogram_game/nonogram_board_controller.dart'
+    show NonogramBoardController;
+import 'presentation/pages/nonogram_game/nonogram_board_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,6 +34,7 @@ class Prisma24App extends StatelessWidget {
   Widget build(BuildContext context) {
 
     Get.put(TangoBoardController());
+    Get.put(NonogramBoardController());
 
     return GetMaterialApp(
       title: 'Prisma 24',
@@ -48,6 +52,7 @@ class Prisma24App extends StatelessWidget {
         '/rank':  (_) => const LeaderboardPage(),
         '/settings': (_) => const SettingsPage(),
         '/tango': (_) => TangoBoardPage(),
+        '/nonogram': (_) => NonogramBoard(),
         '/add_phase': (_) => const AddPhasePage(),
 
       },

--- a/lib/presentation/pages/general_pages/home_page.dart
+++ b/lib/presentation/pages/general_pages/home_page.dart
@@ -52,6 +52,12 @@ class HomePage extends StatelessWidget {
                 onTap: () => Navigator.pushNamed(context, '/tango'),
               ),
               _MenuButton(
+                color: Colors.tealAccent,
+                label: 'Iniciar jogo Nonogram',
+                icon: Icons.play_arrow,
+                onTap: () => Navigator.pushNamed(context, '/nonogram'),
+              ),
+              _MenuButton(
                 color: Colors.purpleAccent,
                 label: 'Iniciar modo completo',
                 icon: Icons.map,

--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -1,0 +1,103 @@
+import 'package:get/get.dart';
+
+/// Controller for the Nonogram puzzle board.
+///
+/// Example JSON to load a puzzle:
+/// ```json
+/// {
+///   "game": "nonogram",
+///   "difficulty": "facil",
+///   "board": {
+///     "size": 5,
+///     "solution": [
+///       [1,0,1,1,0],
+///       [0,1,1,0,1],
+///       [1,1,1,0,0],
+///       [0,0,1,1,1],
+///       [1,0,0,1,0]
+///     ]
+///   }
+/// }
+/// ```
+class NonogramBoardController extends GetxController {
+  final RxInt size = 0.obs;
+  late List<List<int>> solutionMatrix;
+  final RxList<List<int>> currentMatrix = <List<int>>[].obs;
+
+  List<int> rowCounts = [];
+  List<int> colCounts = [];
+
+  @override
+  void onInit() {
+    super.onInit();
+    // Exemplo simples usado quando nenhum JSON é passado
+    loadFromJson({
+      'board': {
+        'size': 5,
+        'solution': [
+          [1, 0, 1, 1, 0],
+          [0, 1, 1, 0, 1],
+          [1, 1, 1, 0, 0],
+          [0, 0, 1, 1, 1],
+          [1, 0, 0, 1, 0]
+        ]
+      }
+    });
+  }
+
+  void loadFromJson(Map<String, dynamic> data) {
+    final board = data['board'] as Map<String, dynamic>;
+    size.value = board['size'] as int;
+    solutionMatrix = [
+      for (final row in board['solution'] as List)
+        List<int>.from(row as List)
+    ];
+    currentMatrix.assignAll(
+      List.generate(size.value, (_) => List.filled(size.value, 0)),
+    );
+    rowCounts = [
+      for (final row in solutionMatrix)
+        row.where((e) => e == 1).length
+    ];
+    colCounts = List.generate(
+      size.value,
+      (c) => solutionMatrix.fold(0, (p, r) => p + (r[c] == 1 ? 1 : 0)),
+    );
+  }
+
+  void toggleTile(int row, int col) {
+    final newVal = currentMatrix[row][col] == 1 ? 0 : 1;
+    currentMatrix[row][col] = newVal;
+    currentMatrix.refresh();
+    if (_checkCompletion()) {
+      Get.dialog(
+        AlertDialog(
+          title: const Text('Parabéns!'),
+          content: const Text('Você completou o puzzle!'),
+          actions: [
+            TextButton(onPressed: Get.back, child: const Text('OK')),
+          ],
+        ),
+        barrierDismissible: false,
+      );
+    }
+  }
+
+  bool _checkCompletion() {
+    for (int i = 0; i < size.value; i++) {
+      for (int j = 0; j < size.value; j++) {
+        if (currentMatrix[i][j] != solutionMatrix[i][j]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  void resetBoard() {
+    for (int i = 0; i < size.value; i++) {
+      currentMatrix[i] = List<int>.filled(size.value, 0);
+    }
+    currentMatrix.refresh();
+  }
+}

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -1,0 +1,131 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'nonogram_board_controller.dart';
+
+class NonogramBoard extends GetView<NonogramBoardController> {
+  const NonogramBoard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Nonogram'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Reiniciar',
+            onPressed: controller.resetBoard,
+          ),
+        ],
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Obx(() {
+              final n = controller.size.value;
+              if (n == 0) {
+                return const CircularProgressIndicator();
+              }
+              return LayoutBuilder(
+                builder: (context, constraints) {
+                  final boardSize = math.min(constraints.maxWidth, constraints.maxHeight) - 24;
+                  final tileSize = boardSize / n;
+                  return SizedBox(
+                    width: boardSize + 24,
+                    height: boardSize + 24,
+                    child: Column(
+                      children: [
+                        Row(
+                          children: [
+                            const SizedBox(width: 24, height: 24),
+                            for (int c = 0; c < n; c++)
+                              SizedBox(
+                                width: tileSize,
+                                child: Center(
+                                  child: Text(
+                                    '${controller.colCounts[c]}',
+                                    style: const TextStyle(fontSize: 12),
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                        for (int r = 0; r < n; r++)
+                          Row(
+                            children: [
+                              SizedBox(
+                                width: 24,
+                                height: tileSize,
+                                child: Center(
+                                  child: Text(
+                                    '${controller.rowCounts[r]}',
+                                    style: const TextStyle(fontSize: 12),
+                                  ),
+                                ),
+                              ),
+                              for (int c = 0; c < n; c++)
+                                SizedBox(
+                                  width: tileSize,
+                                  height: tileSize,
+                                  child: _buildTile(r, c, controller.currentMatrix[r][c]),
+                                ),
+                            ],
+                          ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTile(int row, int col, int state) {
+    return GestureDetector(
+      onTap: () => controller.toggleTile(row, col),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        transitionBuilder: (child, animation) {
+          final rotate = Tween(begin: math.pi, end: 0.0).animate(animation);
+          return AnimatedBuilder(
+            animation: rotate,
+            child: child,
+            builder: (context, widgetChild) {
+              final isUnder = rotate.value > math.pi / 2;
+              final transform = Matrix4.identity()
+                ..setEntry(3, 2, 0.002)
+                ..rotateY(rotate.value);
+              return Transform(
+                transform: transform,
+                alignment: Alignment.center,
+                child: isUnder ? const SizedBox.shrink() : widgetChild,
+              );
+            },
+          );
+        },
+        layoutBuilder: (widget, list) => Stack(children: [widget!, ...list]),
+        switchInCurve: Curves.easeInOut,
+        switchOutCurve: Curves.easeInOut,
+        child: Container(
+          key: ValueKey<int>(state),
+          margin: const EdgeInsets.all(1),
+          decoration: BoxDecoration(
+            color: state == 1 ? Colors.blueAccent : Colors.grey.shade900,
+            borderRadius: BorderRadius.circular(4),
+            border: Border.all(color: Colors.grey.shade700),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a nonogram mini game
- hook the controller up to GetX
- expose the nonogram route in main app routes
- include a new button on the home page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a257c4848321ba86b68d773687a1