### PR TITLE
Apply JSON colors to nonogram board

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -28,6 +28,11 @@ class NonogramBoardController extends GetxController {
   late List<List<int>> solutionMatrix;
   final RxList<List<int>> currentMatrix = <List<int>>[].obs;
 
+  /// Colors used for the tiles. [closedTileColor] is for state 0 and
+  /// [selectedTileColor] for state 1.
+  Color closedTileColor = Colors.grey.shade900;
+  Color selectedTileColor = Colors.blueAccent;
+
   List<int> rowCounts = [];
   List<int> colCounts = [];
 
@@ -44,7 +49,8 @@ class NonogramBoardController extends GetxController {
           [1, 1, 1, 0, 0],
           [1, 1, 1, 1, 1],
           [1, 0, 1, 1, 0]
-        ]
+        ],
+        'colors': ['#222222', 'blue']
       }
     });
   }
@@ -56,6 +62,17 @@ class NonogramBoardController extends GetxController {
       for (final row in board['solution'] as List)
         List<int>.from(row as List)
     ];
+    // Colors configuration
+    final colorsField = board['colors'];
+    if (colorsField is List && colorsField.isNotEmpty) {
+      if (colorsField.length == 1) {
+        selectedTileColor = _parseColor(colorsField[0]);
+        closedTileColor = Colors.white.withOpacity(0.1);
+      } else {
+        closedTileColor = _parseColor(colorsField[0]);
+        selectedTileColor = _parseColor(colorsField[1]);
+      }
+    }
     currentMatrix.assignAll(
       List.generate(size.value, (_) => List.filled(size.value, 0)),
     );
@@ -138,12 +155,57 @@ class NonogramBoardController extends GetxController {
           for (final row in solutionField as List) List<int>.from(row as List)
         ];
       }
-      loadFromJson({'board': {'size': n, 'solution': solution}});
+      final colors = board['colors'];
+      loadFromJson({
+        'board': {
+          'size': n,
+          'solution': solution,
+          'colors': colors,
+        }
+      });
       resetBoard();
     } catch (_) {
     } finally {
       isLoading.value = false;
     }
+  }
+
+  Color _parseColor(dynamic value) {
+    if (value is int) return Color(value);
+    if (value is String) {
+      final v = value.toLowerCase();
+      if (v.startsWith('#')) {
+        final hex = v.substring(1);
+        if (hex.length == 6) {
+          return Color(int.parse('0xFF$hex'));
+        } else if (hex.length == 8) {
+          return Color(int.parse('0x$hex'));
+        }
+      }
+      if (v.startsWith('0x')) {
+        return Color(int.parse(v));
+      }
+      const names = {
+        'black': Colors.black,
+        'white': Colors.white,
+        'red': Colors.red,
+        'green': Colors.green,
+        'blue': Colors.blue,
+        'yellow': Colors.yellow,
+        'grey': Colors.grey,
+        'gray': Colors.grey,
+        'cyan': Colors.cyan,
+        'magenta': Colors.pinkAccent,
+        'purple': Colors.purple,
+        'orange': Colors.orange,
+        'pink': Colors.pink,
+        'brown': Colors.brown,
+        'teal': Colors.teal,
+        'amber': Colors.amber,
+      };
+      return names[v] ?? Colors.blueAccent;
+    }
+    return Colors.blueAccent;
   }
 }
 

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -124,7 +124,9 @@ class NonogramBoard extends GetView<NonogramBoardController> {
           key: ValueKey<int>(state),
           margin: const EdgeInsets.all(1),
           decoration: BoxDecoration(
-            color: state == 1 ? Colors.blueAccent : Colors.grey.shade900,
+            color: state == 1
+                ? controller.selectedTileColor
+                : controller.closedTileColor,
             borderRadius: BorderRadius.circular(4),
             border: Border.all(color: Colors.grey.shade700),
           ),


### PR DESCRIPTION
## Summary
- parse board colors when loading nonogram puzzles
- expose closedTileColor/selectedTileColor and use in board tiles

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1b8866883218eb1e1504512f242