### PR TITLE
Improve map selection and loading

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'firebase_options.dart';
 import 'presentation/pages/general_pages/leaderboard_page.dart';
 import 'presentation/pages/general_pages/settings_page.dart';
 import 'presentation/pages/general_pages/full_mode_page.dart';
+import 'presentation/pages/general_pages/full_mode_map_page.dart';
 import 'presentation/pages/general_pages/add_phase_page.dart';
 import 'presentation/pages/tango_game/tango_board_controller.dart' show TangoBoardController;
 import 'presentation/pages/tango_game/tango_board_page.dart';
@@ -49,6 +50,10 @@ class Prisma24App extends StatelessWidget {
         '/':      (_) => const HomePage(),
         '/prism':  (_) => const GamePage(),
         '/full':   (_) => const FullModePage(),
+        '/full_map': (context) {
+          final id = ModalRoute.of(context)!.settings.arguments as String;
+          return FullModeMapPage(mapId: id);
+        },
         '/rank':  (_) => const LeaderboardPage(),
         '/settings': (_) => const SettingsPage(),
         '/tango': (_) => TangoBoardPage(),

--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../tango_game/tango_board_controller.dart';
+import '../nonogram_game/nonogram_board_controller.dart';
+import '../../widgets/loading_dialog.dart';
+
+class FullModeMapPage extends StatelessWidget {
+  final String mapId;
+  const FullModeMapPage({super.key, required this.mapId});
+
+  static const List<Offset> _relativePoints = [
+    Offset(0.1, 0.85),
+    Offset(0.3, 0.70),
+    Offset(0.15, 0.55),
+    Offset(0.35, 0.40),
+    Offset(0.20, 0.25),
+    Offset(0.50, 0.20),
+    Offset(0.70, 0.35),
+    Offset(0.55, 0.55),
+    Offset(0.75, 0.70),
+    Offset(0.60, 0.85),
+  ];
+
+  Future<int> _phaseCount() async {
+    final snap = await FirebaseFirestore.instance
+        .collection('maps')
+        .doc(mapId)
+        .collection('phases')
+        .get();
+    return snap.size;
+  }
+
+  Future<void> _openPhase(BuildContext context, int i) async {
+    bool closed = false;
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      barrierColor: Colors.black54,
+      builder: (_) => LoadingDialog(onClose: () {
+        closed = true;
+        Navigator.of(context, rootNavigator: true).pop();
+      }),
+    );
+    try {
+      final phases = await FirebaseFirestore.instance
+          .collection('maps')
+          .doc(mapId)
+          .collection('phases')
+          .orderBy('createdAt')
+          .limit(i + 1)
+          .get();
+      if (!closed && phases.docs.length > i) {
+        final data = phases.docs[i].data();
+        final game = data['game'] as String? ?? 'tango';
+        if (game == 'nonogram') {
+          await Get.find<NonogramBoardController>().loadPhase(mapId, i);
+          if (!closed) Navigator.pushNamed(context, '/nonogram');
+        } else {
+          await Get.find<TangoBoardController>().loadPhase(mapId, i);
+          if (!closed) Navigator.pushNamed(context, '/tango');
+        }
+      } else if (!closed) {
+        Get.snackbar('Erro', 'Fase nao implementada',
+            snackPosition: SnackPosition.BOTTOM);
+      }
+    } finally {
+      if (!closed) Navigator.of(context, rootNavigator: true).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: FutureBuilder<int>(
+          future: _phaseCount(),
+          builder: (context, snap) {
+            if (!snap.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final phaseCount = snap.data!;
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                final points = _relativePoints
+                    .map((p) => Offset(
+                          p.dx * constraints.maxWidth,
+                          p.dy * constraints.maxHeight,
+                        ))
+                    .toList();
+                return Stack(
+                  children: [
+                    CustomPaint(
+                      size: Size(constraints.maxWidth, constraints.maxHeight),
+                      painter: _PathPainter(points),
+                    ),
+                    for (int i = 0; i < points.length; i++)
+                      Positioned(
+                        left: points[i].dx - 30,
+                        top: points[i].dy - 30,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.blueAccent,
+                            shape: const CircleBorder(),
+                            padding: const EdgeInsets.all(20),
+                          ),
+                          onPressed: i < phaseCount
+                              ? () => _openPhase(context, i)
+                              : null,
+                          child: Text('${i + 1}'),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _PathPainter extends CustomPainter {
+  final List<Offset> points;
+  _PathPainter(this.points);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (points.length < 2) return;
+    final paint = Paint()
+      ..color = Colors.white38
+      ..strokeWidth = 4
+      ..style = PaintingStyle.stroke;
+    final path = Path()..moveTo(points.first.dx, points.first.dy);
+    for (final p in points.skip(1)) {
+      path.lineTo(p.dx, p.dy);
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/presentation/widgets/loading_dialog.dart
+++ b/lib/presentation/widgets/loading_dialog.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:lottie/lottie.dart';
+
+class LoadingDialog extends StatelessWidget {
+  final VoidCallback onClose;
+  const LoadingDialog({super.key, required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: Stack(
+        children: [
+          Center(
+            child: Lottie.network(
+              'https://assets10.lottiefiles.com/packages/lf20_j1adxtyb.json',
+              width: 160,
+            ),
+          ),
+          Positioned(
+            top: 0,
+            right: 0,
+            child: IconButton(
+              icon: const Icon(Icons.close, color: Colors.red),
+              onPressed: onClose,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add non-cancelable `LoadingDialog` with Lottie animation
- split FullMode into map selector and map page
- add routing for map pages

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b54d1e848321877fd8acdcdbb772