### PR TITLE
Fix loading dialog not closing before phase load

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -36,6 +36,7 @@ class FullModeMapPage extends StatelessWidget {
     bool closed = false;
     showDialog(
       context: context,
+      rootNavigator: true,
       barrierDismissible: false,
       barrierColor: Colors.black54,
       builder: (_) => LoadingDialog(onClose: () {


### PR DESCRIPTION
## Summary
- ensure the loading dialog is displayed and dismissed on the same navigator

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7ba603483218a02d5c1db3a4a42