### PR TITLE
Add progress tracking for map phases

### DIFF
--- a/lib/core/progress_storage.dart
+++ b/lib/core/progress_storage.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ProgressStorage {
+  static const _kKey = 'progress';
+  final SharedPreferences _prefs;
+  ProgressStorage._(this._prefs);
+
+  static Future<ProgressStorage> getInstance() async {
+    final prefs = await SharedPreferences.getInstance();
+    return ProgressStorage._(prefs);
+  }
+
+  Map<String, List<int>> _getAll() {
+    final str = _prefs.getString(_kKey);
+    if (str == null) return {};
+    final decoded = jsonDecode(str) as Map<String, dynamic>;
+    return decoded.map((k, v) => MapEntry(k, List<int>.from(v as List)));
+  }
+
+  List<int> getCompleted(String mapId) {
+    return _getAll()[mapId] ?? <int>[];
+  }
+
+  Future<void> addCompletion(String mapId, int phaseIndex) async {
+    final data = _getAll();
+    final set = {...(data[mapId] ?? <int>[]), phaseIndex};
+    data[mapId] = set.toList()..sort();
+    await _prefs.setString(_kKey, jsonEncode(data));
+  }
+
+  Future<void> reset() async {
+    await _prefs.remove(_kKey);
+  }
+}

--- a/lib/presentation/pages/general_pages/settings_page.dart
+++ b/lib/presentation/pages/general_pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../core/progress_storage.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -78,6 +79,28 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
+  Future<void> _resetProgress() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Resetar progresso?'),
+        content: const Text(
+            'Fases concluídas serão removidas e você terá que jogar tudo novamente.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancelar')),
+          ElevatedButton(onPressed: () => Navigator.pop(context, true), child: const Text('Confirmar')),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      final storage = await ProgressStorage.getInstance();
+      await storage.reset();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Progresso apagado')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -99,6 +122,13 @@ class _SettingsPageState extends State<SettingsPage> {
           ListTile(
             title: const Text('Versão do app'),
             subtitle: Text(_version.isEmpty ? '...' : _version),
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Resetar fases'),
+            subtitle: const Text('Apagar progresso salvo'),
+            trailing: const Icon(Icons.restore),
+            onTap: _resetProgress,
           ),
           const Divider(),
           ListTile(

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import '../../../core/progress_storage.dart';
 
 class TangoBoardController extends GetxController {
   /// Dimensão do tabuleiro (NxN)
@@ -28,6 +29,9 @@ class TangoBoardController extends GetxController {
   final RxList<Hint> hints = <Hint>[].obs;
 
   final Random _random = Random();
+
+  String? currentMapId;
+  int? currentPhaseIndex;
 
 
   @override
@@ -188,6 +192,10 @@ class TangoBoardController extends GetxController {
 
     // 5) Se terminado, exibe o diálogo
     if (_checkCompletion()) {
+      if (currentMapId != null && currentPhaseIndex != null) {
+        ProgressStorage.getInstance().then(
+            (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
+      }
       Get.dialog(
         AlertDialog(
           title: const Text('Parabéns!'),
@@ -223,6 +231,8 @@ void resetBoard() {
 
   Future<void> loadPhase(String mapId, int index) async {
     isLoading.value = true;
+    currentMapId = mapId;
+    currentPhaseIndex = index;
     try {
       final phases = await FirebaseFirestore.instance
           .collection('maps')


### PR DESCRIPTION
## Summary
- implement ProgressStorage using SharedPreferences
- show list of maps with cards including creation date
- mark completed phases with check icon in map view
- save progress when finishing Nonogram or Tango phase
- add reset progress option in settings

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc8d6d648321955e2e0fbda0b969