### PR TITLE
Return to map after finishing puzzles

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -105,7 +105,13 @@ class NonogramBoardController extends GetxController {
           title: const Text('Parabéns!'),
           content: const Text('Você completou o puzzle!'),
           actions: [
-            TextButton(onPressed: Get.back, child: const Text('OK')),
+            TextButton(
+              onPressed: () {
+                Get.back();
+                Get.back();
+              },
+              child: const Text('OK'),
+            ),
           ],
         ),
         barrierDismissible: false,

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -202,7 +202,10 @@ class TangoBoardController extends GetxController {
           content: const Text('Você completou o puzzle!'),
           actions: [
             TextButton(
-              onPressed: () => Get.back(),
+              onPressed: () {
+                Get.back();
+                Get.back();
+              },
               child: const Text('OK'),
             ),
           ],


### PR DESCRIPTION
## Summary
- navigate back to the map after finishing a Tango or Nonogram puzzle

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf8d29508321b4ed6e05bda852d5