### PR TITLE
Add global lives system

### DIFF
--- a/lib/core/life_manager.dart
+++ b/lib/core/life_manager.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LifeManager extends ChangeNotifier {
+  LifeManager._internal();
+  static final LifeManager _instance = LifeManager._internal();
+  factory LifeManager() => _instance;
+
+  static const int maxLives = 5;
+  static const Duration refillDuration = Duration(minutes: 10);
+
+  static const _kLivesKey = 'lives';
+
+  late SharedPreferences _prefs;
+  int _lives = maxLives;
+  Timer? _timer;
+  Duration _timeLeft = refillDuration;
+
+  int get lives => _lives;
+  Duration get timeLeft => _timeLeft;
+  bool get isFull => _lives >= maxLives;
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _lives = _prefs.getInt(_kLivesKey) ?? maxLives;
+    if (_lives < maxLives) {
+      _startTimer();
+    }
+    notifyListeners();
+  }
+
+  Future<void> _saveLives() async {
+    await _prefs.setInt(_kLivesKey, _lives);
+  }
+
+  void loseLife() {
+    if (_lives == 0) return;
+    _lives--;
+    _saveLives();
+    notifyListeners();
+    if (_lives < maxLives && _timer == null) {
+      _startTimer();
+    }
+  }
+
+  void _startTimer() {
+    _timeLeft = refillDuration;
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
+      _timeLeft -= const Duration(seconds: 1);
+      if (_timeLeft.isNegative) _timeLeft = Duration.zero;
+      notifyListeners();
+      if (_timeLeft.inSeconds <= 0) {
+        t.cancel();
+        _timer = null;
+        _addLife();
+      }
+    });
+  }
+
+  void _addLife() {
+    if (_lives < maxLives) {
+      _lives++;
+      _saveLives();
+      notifyListeners();
+      if (_lives < maxLives) {
+        _startTimer();
+      }
+    } else {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'presentation/pages/tango_game/tango_board_page.dart';
 import 'presentation/pages/nonogram_game/nonogram_board_controller.dart'
     show NonogramBoardController;
 import 'presentation/pages/nonogram_game/nonogram_board_page.dart';
+import 'core/life_manager.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,6 +25,8 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  await LifeManager().init();
 
   runApp(const ProviderScope(child: Prisma24App()));
 }

--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -7,6 +7,7 @@ import '../../../core/progress_storage.dart';
 import '../tango_game/tango_board_controller.dart';
 import '../nonogram_game/nonogram_board_controller.dart';
 import '../../widgets/loading_dialog.dart';
+import '../../widgets/lives_bar.dart';
 
 class FullModeMapPage extends StatefulWidget {
   final String mapId;
@@ -165,6 +166,12 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
                 }
                 return Stack(
                   children: [
+                    const Positioned(
+                      top: 8,
+                      left: 8,
+                      right: 8,
+                      child: Center(child: LivesBar()),
+                    ),
                     CustomPaint(
                       size: Size(constraints.maxWidth, constraints.maxHeight),
                       painter: _PathPainter(points),

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import '../../core/life_manager.dart';
 import 'nonogram_board_controller.dart';
 
 class NonogramBoard extends GetView<NonogramBoardController> {
@@ -8,7 +9,12 @@ class NonogramBoard extends GetView<NonogramBoardController> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return WillPopScope(
+      onWillPop: () async {
+        LifeManager().loseLife();
+        return true;
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Nonogram'),
         actions: [
@@ -90,6 +96,7 @@ class NonogramBoard extends GetView<NonogramBoardController> {
             }),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -9,6 +9,7 @@ import 'package:lottie/lottie.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../core/sfx.dart';
+import '../../../core/life_manager.dart';
 import '../../../domain/models/prism_game_models/game_state.dart';
 import '../../providers/prism_game_provider/game_provider.dart';
 import '../../widgets/prism_game_widgets/hex_board.dart';
@@ -54,6 +55,7 @@ class GamePage extends ConsumerWidget {
         ),
       ),
     );
+    );
   }
 
     Future<void> saveScore(String name, int score) =>
@@ -69,6 +71,7 @@ class GamePage extends ConsumerWidget {
 
   void _showEndDialog(
       BuildContext context, WidgetRef ref, bool won, int elapsed) {
+      if (!won) LifeManager().loseLife();
       final base   = ref.read(gameProvider.notifier).baseTiles;
       final moves  = ref.read(gameProvider.notifier).movesUsed;
       final bonus  = (10 * base / max(moves, 1)).floor();
@@ -107,7 +110,8 @@ class GamePage extends ConsumerWidget {
           ),
         ],
       ),
-    );
+    ),
+  );
   }
 
   /* ─────────────────────── Build ─────────────────────── */
@@ -138,8 +142,15 @@ class GamePage extends ConsumerWidget {
   final currentScore = base + bonus;   // sem penalidade de tempo ainda
 
 
-    return Scaffold(
-      appBar: AppBar(
+    return WillPopScope(
+      onWillPop: () async {
+        if (ref.read(gameProvider).status != GameStatus.won) {
+          LifeManager().loseLife();
+        }
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
         backgroundColor:
             controller.isAwaitingBomb ? Colors.orange.shade700 : Colors.transparent,
         elevation: 0,
@@ -175,7 +186,12 @@ class GamePage extends ConsumerWidget {
           IconButton(
             tooltip: 'Home',
             icon: const Icon(Icons.home),
-            onPressed: () => Navigator.pop(context),
+            onPressed: () {
+              if (ref.read(gameProvider).status != GameStatus.won) {
+                LifeManager().loseLife();
+              }
+              Navigator.pop(context);
+            },
           ),
           IconButton(
             tooltip: 'Ajuda',
@@ -257,7 +273,8 @@ class GamePage extends ConsumerWidget {
           ),
         ),
       ),
-    );
+    ),
+  );
   }
 
   /* ───────── helpers ───────── */

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import '../../core/life_manager.dart';
 import 'tango_board_controller.dart';
 
 class TangoBoardPage extends GetView<TangoBoardController> {
@@ -11,7 +12,12 @@ class TangoBoardPage extends GetView<TangoBoardController> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return WillPopScope(
+      onWillPop: () async {
+        LifeManager().loseLife();
+        return true;
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Tango Puzzle'),
         backgroundColor: Colors.black,
@@ -207,6 +213,7 @@ class TangoBoardPage extends GetView<TangoBoardController> {
         ],
       ),
     ),
+      ),
       ),
     );
   }

--- a/lib/presentation/widgets/lives_bar.dart
+++ b/lib/presentation/widgets/lives_bar.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import '../../core/life_manager.dart';
+
+class LivesBar extends StatefulWidget {
+  const LivesBar({super.key});
+
+  @override
+  State<LivesBar> createState() => _LivesBarState();
+}
+
+class _LivesBarState extends State<LivesBar> {
+  final manager = LifeManager();
+
+  @override
+  void initState() {
+    super.initState();
+    manager.addListener(_update);
+  }
+
+  @override
+  void dispose() {
+    manager.removeListener(_update);
+    super.dispose();
+  }
+
+  void _update() => setState(() {});
+
+  String _format(Duration d) {
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.favorite, color: Colors.redAccent),
+        const SizedBox(width: 4),
+        Text('${manager.lives}'),
+        if (!manager.isFull) ...[
+          const SizedBox(width: 16),
+          const Icon(Icons.timer, size: 18),
+          const SizedBox(width: 4),
+          Text(_format(manager.timeLeft)),
+        ],
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `LifeManager` singleton using SharedPreferences
- display a `LivesBar` with hearts and timer on the map screen
- decrease lives when leaving or losing a stage
- start lives service on app startup

## Testing
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb8a15908321a875f4eb65f12dd4