### PR TITLE
Implement life gating and pop confirmation

### DIFF
--- a/lib/core/life_manager.dart
+++ b/lib/core/life_manager.dart
@@ -72,4 +72,13 @@ class LifeManager extends ChangeNotifier {
       _timer = null;
     }
   }
+
+  /// Fills lives to the maximum value immediately.
+  void fillLives() {
+    _lives = maxLives;
+    _timer?.cancel();
+    _timer = null;
+    _saveLives();
+    notifyListeners();
+  }
 }

--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'dart:math';
 
 import '../../../core/progress_storage.dart';
+import '../../../core/life_manager.dart';
 import '../tango_game/tango_board_controller.dart';
 import '../nonogram_game/nonogram_board_controller.dart';
 import '../../widgets/loading_dialog.dart';
@@ -83,6 +84,29 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
   }
 
   Future<void> _openPhase(BuildContext context, int i) async {
+    if (LifeManager().lives == 0) {
+      await showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Sem vidas'),
+          content: const Text('Você não tem mais vidas para jogar.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Fechar'),
+            ),
+            TextButton(
+              onPressed: () {
+                LifeManager().fillLives();
+                Navigator.pop(context);
+              },
+              child: const Text('Assistir anúncio'),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
     bool closed = false;
     showDialog(
       context: context,

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -7,12 +7,40 @@ import 'nonogram_board_controller.dart';
 class NonogramBoard extends GetView<NonogramBoardController> {
   const NonogramBoard({super.key});
 
+  Future<bool> _confirmExit(BuildContext context) async {
+    final res = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Sair da fase?'),
+        content: const Text('Você perderá uma vida se sair agora.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Sair'),
+          ),
+        ],
+      ),
+    );
+    if (res == true) {
+      LifeManager().loseLife();
+      return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        LifeManager().loseLife();
-        return true;
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) return;
+        if (await _confirmExit(context)) {
+          Navigator.pop(context);
+        }
       },
       child: Scaffold(
       appBar: AppBar(

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -10,12 +10,40 @@ import 'tango_board_controller.dart';
 class TangoBoardPage extends GetView<TangoBoardController> {
   const TangoBoardPage({super.key});
 
+  Future<bool> _confirmExit(BuildContext context) async {
+    final res = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Sair da fase?'),
+        content: const Text('Você perderá uma vida se sair agora.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Sair'),
+          ),
+        ],
+      ),
+    );
+    if (res == true) {
+      LifeManager().loseLife();
+      return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        LifeManager().loseLife();
-        return true;
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) return;
+        if (await _confirmExit(context)) {
+          Navigator.pop(context);
+        }
       },
       child: Scaffold(
       appBar: AppBar(

--- a/lib/presentation/widgets/loading_dialog.dart
+++ b/lib/presentation/widgets/loading_dialog.dart
@@ -7,8 +7,9 @@ class LoadingDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async => false,
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) {},
       child: Stack(
         children: [
           Center(


### PR DESCRIPTION
## Summary
- ensure life manager can refill lives instantly
- block phase start when player has no lives
- switch to `PopScope` and confirm exit from stages

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d08d41b4832196843547bbd15d25