### PR TITLE
Fix warnings in app

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -126,7 +126,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
           .orderBy('createdAt')
           .limit(i + 1)
           .get();
-      if (!closed && phases.docs.length > i) {
+      if (!closed && context.mounted && phases.docs.length > i) {
         final data = phases.docs[i].data();
         final game = data['game'] as String? ?? 'tango';
         if (game == 'nonogram') {

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -36,9 +36,9 @@ class NonogramBoard extends GetView<NonogramBoardController> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) async {
+      onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
-        if (await _confirmExit(context)) {
+        if (await _confirmExit(context) && context.mounted) {
           Navigator.pop(context);
         }
       },

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -168,9 +168,9 @@ class GamePage extends ConsumerWidget {
 
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) async {
+      onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
-        if (await _confirmExit(context)) {
+        if (await _confirmExit(context) && context.mounted) {
           Navigator.pop(context);
         }
       },
@@ -212,7 +212,7 @@ class GamePage extends ConsumerWidget {
             tooltip: 'Home',
             icon: const Icon(Icons.home),
             onPressed: () async {
-              if (await _confirmExit(context)) {
+              if (await _confirmExit(context) && context.mounted) {
                 Navigator.pop(context);
               }
             },

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -39,9 +39,9 @@ class TangoBoardPage extends GetView<TangoBoardController> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) async {
+      onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
-        if (await _confirmExit(context)) {
+        if (await _confirmExit(context) && context.mounted) {
           Navigator.pop(context);
         }
       },

--- a/lib/presentation/widgets/loading_dialog.dart
+++ b/lib/presentation/widgets/loading_dialog.dart
@@ -9,7 +9,7 @@ class LoadingDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) {},
+      onPopInvokedWithResult: (didPop, result) {},
       child: Stack(
         children: [
           Center(


### PR DESCRIPTION
## Summary
- fix asynchronous context usage in navigation checks
- update deprecated `onPopInvoked` callbacks to `onPopInvokedWithResult`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d7a469d883219028d8dd90b93a4f