### PR TITLE
Enable Firestore persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 // lib/main.dart
 import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
@@ -27,6 +28,10 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
+  // Enable offline persistence for Firestore
+  await FirebaseFirestore.instance.settings =
+      const Settings(persistenceEnabled: true);
 
   await LifeManager().init();
 


### PR DESCRIPTION
## Summary
- enable Firestore offline persistence by setting `Settings(persistenceEnabled: true)`
- import Firestore package in main.dart

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e15d7d848321bfb2f8a3d192b0ce