### PR TITLE
Add translucent backgrounds for map UI elements

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -247,7 +247,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
     return Scaffold(
       extendBodyBehindAppBar: true,
       appBar: AppBar(
-        backgroundColor: Colors.transparent,
+        backgroundColor: Colors.black54,
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),

--- a/lib/presentation/widgets/lives_bar.dart
+++ b/lib/presentation/widgets/lives_bar.dart
@@ -33,19 +33,26 @@ class _LivesBarState extends State<LivesBar> {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        const Icon(Icons.favorite, color: Colors.redAccent),
-        const SizedBox(width: 4),
-        Text('${manager.lives}'),
-        if (!manager.isFull) ...[
-          const SizedBox(width: 16),
-          const Icon(Icons.timer, size: 18),
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.favorite, color: Colors.redAccent),
           const SizedBox(width: 4),
-          Text(_format(manager.timeLeft)),
+          Text('${manager.lives}'),
+          if (!manager.isFull) ...[
+            const SizedBox(width: 16),
+            const Icon(Icons.timer, size: 18),
+            const SizedBox(width: 4),
+            Text(_format(manager.timeLeft)),
+          ],
         ],
-      ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- give the `AppBar` on the map page a translucent look
- put the `LivesBar` content inside a translucent container

## Testing
- `dart format lib/presentation/widgets/lives_bar.dart lib/presentation/pages/general_pages/full_mode_map_page.dart` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842190db8688321ae1011da420fe779