### PR TITLE
Update UI with translucent map buttons

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -115,6 +115,8 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
                 image: AssetImage(btnPath),
                 fit: BoxFit.cover,
               ),
+              border: Border.all(color: Colors.white54, width: 2),
+              shape: BoxShape.circle,
             ),
             child: Center(child: _outlinedText('${i + 1}')),
           ),
@@ -135,6 +137,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
             decoration: const BoxDecoration(
               color: Colors.blueAccent,
               shape: BoxShape.circle,
+              border: Border.all(color: Colors.white54, width: 2),
             ),
             child: _outlinedText('${i + 1}'),
           ),
@@ -311,6 +314,12 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.pop(context),
         ),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: LivesBar(),
+          ),
+        ],
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -344,12 +353,6 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
                 }
                 return Stack(
                   children: [
-                    const Positioned(
-                      top: 120,
-                      left: 8,
-                      right: 8,
-                      child: LivesBar(),
-                    ),
                     CustomPaint(
                       size: Size(constraints.maxWidth, constraints.maxHeight),
                       painter: _PathPainter(points),

--- a/lib/presentation/pages/general_pages/full_mode_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_page.dart
@@ -46,9 +46,24 @@ class FullModePage extends StatelessWidget {
               final id = map['id'] as String;
               final date = map['createdAt'] as DateTime?;
               final message = map['message'] as String?;
+              final theme = map['theme'] as String? ?? '';
+              final bgPath = theme.isNotEmpty
+                  ? (theme.contains('/')
+                      ? theme
+                      : 'assets/images/ui/bgs/$theme')
+                  : 'assets/images/ui/bg_gradient.png';
               return Card(
                 margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: ListTile(
+                color: Colors.transparent,
+                clipBehavior: Clip.antiAlias,
+                child: Container(
+                  decoration: BoxDecoration(
+                    image: DecorationImage(
+                      image: AssetImage(bgPath),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                  child: ListTile(
                   title: Text('map'.trArgs(['${i + 1}'])),
                   subtitle: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -67,6 +82,7 @@ class FullModePage extends StatelessWidget {
                       builder: (_) => FullModeMapPage(mapId: id),
                       settings: const RouteSettings(name: '/full_map'),
                     ),
+                  ),
                   ),
                 ),
               );


### PR DESCRIPTION
## Summary
- add translucent border around phase buttons
- move `LivesBar` into the map page `AppBar`
- show map card background images transparently in map list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421ca624bc83218009f5da4b2a0e03