### PR TITLE
Fix map card background

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_page.dart
@@ -65,20 +65,20 @@ class FullModePage extends StatelessWidget {
                 clipBehavior: Clip.antiAlias,
                 child: Stack(
                   children: [
-                    Container(
-                      decoration: BoxDecoration(
-                        image: DecorationImage(
-                          image: AssetImage(bgPath),
-                          fit: BoxFit.cover,
-                        ),
+                    Positioned.fill(
+                      child: Image.asset(
+                        bgPath,
+                        fit: BoxFit.cover,
                       ),
                     ),
-                    Container(
-                      decoration: const BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [Colors.transparent, Colors.black54],
+                    Positioned.fill(
+                      child: Container(
+                        decoration: const BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [Colors.transparent, Colors.black54],
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- ensure map background from Firestore fills card

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684221e1242c8321a735e424dea42463