### PR TITLE
Remove circular borders from buttons

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -115,7 +115,6 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
                 image: AssetImage(btnPath),
                 fit: BoxFit.cover,
               ),
-              border: Border.all(color: Colors.white54, width: 2),
               shape: BoxShape.circle,
             ),
             child: Center(child: _outlinedText('${i + 1}')),
@@ -137,7 +136,6 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
             decoration: BoxDecoration(
               color: Colors.blueAccent,
               shape: BoxShape.circle,
-              border: Border.all(color: Colors.white54, width: 2),
             ),
             child: _outlinedText('${i + 1}'),
           ),

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -402,7 +402,6 @@ class _ColorDot extends StatelessWidget {
       decoration: BoxDecoration(
         color: color,
         shape: BoxShape.circle,
-        border: Border.all(color: Colors.white, width: selected ? 3 : 1.5),
         boxShadow: [
           if (selected) const BoxShadow(blurRadius: 6, spreadRadius: 1),
         ],


### PR DESCRIPTION
## Summary
- remove circle borders on map phase buttons
- remove outline from color palette buttons

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842249d36688321ac1e819d722e0218