### PR TITLE
Adjust map button shadows

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -102,6 +102,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
     if (btnPath != null) {
       button = Material(
         elevation: 1,
+        shadowColor: Colors.black54,
         shape: const CircleBorder(),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
@@ -124,6 +125,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
     } else {
       button = Material(
         elevation: 2,
+        shadowColor: Colors.black54,
         shape: const CircleBorder(),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
@@ -367,6 +369,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
                         top: nextPoint.dy - 30,
                         child: Material(
                           elevation: 4,
+                          shadowColor: Colors.black54,
                           shape: const CircleBorder(),
                           clipBehavior: Clip.antiAlias,
                           child: InkWell(


### PR DESCRIPTION
## Summary
- tweak map button Material shadow colors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842261a845c8321b59fdb4a841c9f8e