### PR TITLE
Hide unimplemented phases

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -95,7 +95,8 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
   }
 
   Widget _phaseButton(BuildContext context, int i, int phaseCount) {
-    final onTap = i < phaseCount ? () => _openPhase(context, i) : null;
+    if (i >= phaseCount) return const SizedBox.shrink();
+    final onTap = () => _openPhase(context, i);
     final completed = _completed.contains(i);
     final btnPath = _btnPath;
     Widget button;


### PR DESCRIPTION
## Summary
- hide map phase buttons when no phase exists in Firestore

## Testing
- `flutter format lib/presentation/pages/general_pages/full_mode_map_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422ae06320832188a6daea65e6cc45