### PR TITLE
Implement global sound toggle and game effects

### DIFF
--- a/lib/core/sfx.dart
+++ b/lib/core/sfx.dart
@@ -1,4 +1,5 @@
 import 'package:audioplayers/audioplayers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class Sfx {
   Sfx._internal();
@@ -6,7 +7,33 @@ class Sfx {
   static final Sfx _instance = Sfx._internal();
   factory Sfx() => _instance;
 
-  final _cache = AudioPlayer(playerId: 'sfx')..setReleaseMode(ReleaseMode.stop);
+  static const soundPrefKey = 'sound_on';
 
-  Future<void> tap() => _cache.play(AssetSource('audio/tap.wav'));
+  final AudioPlayer _cache =
+      AudioPlayer(playerId: 'sfx')..setReleaseMode(ReleaseMode.stop);
+
+  bool _enabled = true;
+
+  bool get enabled => _enabled;
+  set enabled(bool v) => _enabled = v;
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    _enabled = prefs.getBool(soundPrefKey) ?? true;
+  }
+
+  Future<void> tap() async {
+    if (!_enabled) return;
+    await _cache.play(AssetSource('audio/tap.wav'));
+  }
+
+  Future<void> win() async {
+    if (!_enabled) return;
+    await _cache.play(AssetSource('audio/win.wav'));
+  }
+
+  Future<void> fail() async {
+    if (!_enabled) return;
+    await _cache.play(AssetSource('audio/fail.mp3'));
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'presentation/pages/nonogram_game/nonogram_board_controller.dart'
     show NonogramBoardController;
 import 'presentation/pages/nonogram_game/nonogram_board_page.dart';
 import 'core/life_manager.dart';
+import 'core/sfx.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -34,6 +35,8 @@ void main() async {
       const Settings(persistenceEnabled: true);
 
   await LifeManager().init();
+
+  await Sfx().init();
 
   final prefs = await SharedPreferences.getInstance();
   final code = prefs.getString('locale') ?? 'pt_BR';

--- a/lib/presentation/pages/general_pages/settings_page.dart
+++ b/lib/presentation/pages/general_pages/settings_page.dart
@@ -7,6 +7,7 @@ import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import '../../../core/progress_storage.dart';
+import '../../../core/sfx.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -17,7 +18,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   /* chaves no SharedPreferences */
-  static const _kSoundKey = 'sound_on';
+  static const _kSoundKey = Sfx.soundPrefKey;
   static const _kNameKey  = 'player_name';
   static const _kLocaleKey = 'locale';
 
@@ -50,6 +51,7 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _toggleSound(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_kSoundKey, value);
+    Sfx().enabled = value;
     setState(() => _soundOn = value);
   }
 

--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../core/progress_storage.dart';
 import '../../../core/life_manager.dart';
+import '../../../core/sfx.dart';
 
 /// Controller for the Nonogram puzzle board.
 ///
@@ -69,6 +70,7 @@ class NonogramBoardController extends GetxController {
   }
 
   void _handleLoss() {
+    Sfx().fail();
     _stopTimer();
     LifeManager().loseLife();
     Get.dialog(
@@ -147,12 +149,14 @@ class NonogramBoardController extends GetxController {
 
   void toggleTile(int row, int col) {
     isLoading.value = true;
+    Sfx().tap();
     final newVal = currentMatrix[row][col] == 1 ? 0 : 1;
     currentMatrix[row][col] = newVal;
     currentMatrix.refresh();
     clicks.value++;
     _updateScore();
     if (_checkCompletion()) {
+      Sfx().win();
       _stopTimer();
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/life_manager.dart';
+import '../../../core/sfx.dart';
 import 'nonogram_board_controller.dart';
 
 class NonogramBoard extends GetView<NonogramBoardController> {
@@ -50,7 +51,10 @@ class NonogramBoard extends GetView<NonogramBoardController> {
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'restart'.tr,
-            onPressed: controller.resetBoard,
+            onPressed: () {
+              controller.resetBoard();
+              Sfx().tap();
+            },
           ),
         ],
       ),

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/progress_storage.dart';
 import '../../../core/life_manager.dart';
+import '../../../core/sfx.dart';
 
 class TangoBoardController extends GetxController {
   /// Dimensão do tabuleiro (NxN)
@@ -70,6 +71,7 @@ class TangoBoardController extends GetxController {
   }
 
   void _handleLoss() {
+    Sfx().fail();
     if (_timer != null) {
       _stopTimer();
     }
@@ -200,6 +202,7 @@ class TangoBoardController extends GetxController {
   /// Se não houver mais dicas para revelar, não faz nada.
   void revealHint() {
     isLoading.value = true;
+    Sfx().tap();
     // Filtra apenas as dicas que ainda estão ocultas
     final ocultas = hints.where((h) => h.hidden).toList();
     if (ocultas.isEmpty) return;
@@ -230,6 +233,7 @@ class TangoBoardController extends GetxController {
   /// Cicla o estado de uma célula: 0 -> 1 -> 2 -> 0
   void cycleTile(int row, int col) {
     isLoading.value = true;
+    Sfx().tap();
     // 1) Se veio pré-preenchido, bloqueia alteração
     if (initialMatrix[row][col] != 0) return;
 
@@ -248,6 +252,7 @@ class TangoBoardController extends GetxController {
 
     // 5) Se terminado, exibe o diálogo
     if (_checkCompletion()) {
+      Sfx().win();
       _stopTimer();
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/life_manager.dart';
+import '../../../core/sfx.dart';
 import 'tango_board_controller.dart';
 
 class TangoBoardPage extends GetView<TangoBoardController> {
@@ -55,6 +56,7 @@ class TangoBoardPage extends GetView<TangoBoardController> {
             icon: const Icon(Icons.refresh, color: Colors.white),
             onPressed: () {
               controller.resetBoard();
+              Sfx().tap();
             },
             tooltip: 'restart'.tr,
           ),
@@ -86,6 +88,7 @@ class TangoBoardPage extends GetView<TangoBoardController> {
                       onPressed: remaining > 0
                           ? () {
                               controller.revealHint();
+                              Sfx().tap();
                             }
                           : null, // desabilita se não há mais dicas
                     ),


### PR DESCRIPTION
## Summary
- enable audio toggle persistence via `Sfx` and update settings page
- play tap/win/fail sounds across Tango and Nonogram games
- initialize Sfx with saved preference on startup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68422d451e5083219283c5dfc4ad6794