### PR TITLE
Implement map score tracking and leaderboards

### DIFF
--- a/lib/core/leaderboard_service.dart
+++ b/lib/core/leaderboard_service.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'progress_storage.dart';
+import 'player_prefs.dart';
+
+class LeaderboardService {
+  LeaderboardService._();
+  static final LeaderboardService _instance = LeaderboardService._();
+  factory LeaderboardService() => _instance;
+
+  final _firestore = FirebaseFirestore.instance;
+
+  Future<void> savePhaseScore(String mapId, int phaseIndex, int score) async {
+    final name = await getPlayerName();
+    await _firestore.collection('phase_scores').add({
+      'mapId': mapId,
+      'phase': phaseIndex,
+      'name': name,
+      'score': score,
+      'ts': FieldValue.serverTimestamp(),
+    });
+
+    final storage = await ProgressStorage.getInstance();
+    await storage.setHighScore(mapId, phaseIndex, score);
+    final total = storage.getMapTotal(mapId);
+    await _firestore
+        .collection('map_leaderboards')
+        .doc('$mapId-$name')
+        .set({'mapId': mapId, 'name': name, 'score': total, 'ts': FieldValue.serverTimestamp()});
+  }
+}

--- a/lib/core/player_prefs.dart
+++ b/lib/core/player_prefs.dart
@@ -1,0 +1,6 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<String> getPlayerName() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString('player_name') ?? 'Jogador';
+}

--- a/lib/core/progress_storage.dart
+++ b/lib/core/progress_storage.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class ProgressStorage {
   static const _kKey = 'progress';
+  static const _kScoreKey = 'scores';
   final SharedPreferences _prefs;
   ProgressStorage._(this._prefs);
 
@@ -31,5 +32,42 @@ class ProgressStorage {
 
   Future<void> reset() async {
     await _prefs.remove(_kKey);
+    await _prefs.remove(_kScoreKey);
+  }
+
+  Map<String, Map<String, int>> _getScores() {
+    final str = _prefs.getString(_kScoreKey);
+    if (str == null) return {};
+    final decoded = jsonDecode(str) as Map<String, dynamic>;
+    return decoded.map((k, v) {
+      final inner = v as Map<String, dynamic>;
+      return MapEntry(
+        k,
+        inner.map((p, s) => MapEntry(p, s as int)),
+      );
+    });
+  }
+
+  int getHighScore(String mapId, int phaseIndex) {
+    final mapScores = _getScores()[mapId];
+    if (mapScores == null) return 0;
+    return mapScores['$phaseIndex'] ?? 0;
+  }
+
+  int getMapTotal(String mapId) {
+    final mapScores = _getScores()[mapId];
+    if (mapScores == null) return 0;
+    return mapScores.values.fold(0, (p, v) => p + v);
+  }
+
+  Future<void> setHighScore(String mapId, int phaseIndex, int score) async {
+    final data = _getScores();
+    final mapScores = data.putIfAbsent(mapId, () => {});
+    final key = '$phaseIndex';
+    final current = mapScores[key] ?? 0;
+    if (score > current) {
+      mapScores[key] = score;
+      await _prefs.setString(_kScoreKey, jsonEncode(data));
+    }
   }
 }

--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -24,6 +24,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
   String? _nextMapId;
   String? _bgAsset;
   String? _btnAsset;
+  int _mapTotal = 0;
 
   String get _bgPath {
     if (_bgAsset == null) return 'assets/images/ui/bg_gradient.png';
@@ -179,6 +180,7 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
     final storage = await ProgressStorage.getInstance();
     setState(() {
       _completed = storage.getCompleted(widget.mapId);
+      _mapTotal = storage.getMapTotal(widget.mapId);
     });
   }
 
@@ -313,6 +315,8 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
       appBar: AppBar(
         backgroundColor: Colors.black54,
         elevation: 0,
+        centerTitle: true,
+        title: Text('$_mapTotal'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.pop(context),

--- a/lib/presentation/pages/general_pages/leaderboard_page.dart
+++ b/lib/presentation/pages/general_pages/leaderboard_page.dart
@@ -1,65 +1,62 @@
-// lib/presentation/pages/leaderboard_page.dart
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
 
-/// Página que exibe o TOP-100 de pontuações, em tempo real, via Firestore.
 class LeaderboardPage extends StatelessWidget {
   const LeaderboardPage({super.key});
 
-  /// Stream ordenada (desc) por score, limitada a 100 documentos.
-  Stream<QuerySnapshot<Map<String, dynamic>>> _top100Stream() =>
+  Stream<QuerySnapshot<Map<String, dynamic>>> _maps() => FirebaseFirestore.instance
+      .collection('maps')
+      .orderBy('createdAt')
+      .snapshots();
+
+  Stream<QuerySnapshot<Map<String, dynamic>>> _leaders(String mapId) =>
       FirebaseFirestore.instance
-          .collection('scores')
+          .collection('map_leaderboards')
+          .where('mapId', isEqualTo: mapId)
           .orderBy('score', descending: true)
-          .limit(100)
+          .limit(5)
           .snapshots();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('top100'.tr),
-      ),
+      appBar: AppBar(title: Text('leaderboards'.tr)),
       body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-        stream: _top100Stream(),
+        stream: _maps(),
         builder: (context, snap) {
-          if (snap.hasError) {
-            return Center(child: Text('Erro: ${snap.error}'));
-          }
-          if (snap.connectionState == ConnectionState.waiting) {
+          if (!snap.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
-          final docs = snap.data!.docs;
-          if (docs.isEmpty) {
-            return Center(child: Text('no_scores'.tr));
+          final maps = snap.data!.docs;
+          if (maps.isEmpty) {
+            return Center(child: Text('no_maps'.tr));
           }
-
-          return ListView.separated(
-            itemCount: docs.length,
-            separatorBuilder: (_, __) => const Divider(height: 1),
-            itemBuilder: (context, i) {
-              final data = docs[i].data();
-              final name  = data['name']  ?? 'Jogador';
-              final score = data['score'] ?? 0;
-              return ListTile(
-                leading: Text(
-                  '#${i + 1}',
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+          return ListView(
+            children: [
+              for (final m in maps)
+                StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                  stream: _leaders(m.id),
+                  builder: (context, snap2) {
+                    final docs = snap2.data?.docs ?? [];
+                    final first = docs.isNotEmpty ? docs.first.data() : null;
+                    return ExpansionTile(
+                      title: Text(m.id),
+                      subtitle: first != null
+                          ? Text('${first['name']} - ${first['score']}')
+                          : Text('no_scores'.tr),
+                      children: [
+                        for (int i = 1; i < docs.length; i++)
+                          ListTile(
+                            leading: Text('#${i + 1}'),
+                            title: Text(docs[i]['name']),
+                            trailing: Text('${docs[i]['score']}'),
+                          ),
+                      ],
+                    );
+                  },
                 ),
-                title: Text(name),
-                trailing: Text(
-                  '$score',
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              );
-            },
+            ],
           );
         },
       ),

--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -7,6 +7,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../core/progress_storage.dart';
 import '../../../core/life_manager.dart';
 import '../../../core/sfx.dart';
+import '../../../core/leaderboard_service.dart';
 
 /// Controller for the Nonogram puzzle board.
 ///
@@ -161,6 +162,8 @@ class NonogramBoardController extends GetxController {
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(
             (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
+        LeaderboardService()
+            .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
       }
       Get.dialog(
         AlertDialog(

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -6,7 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lottie/lottie.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import '../../core/player_prefs.dart';
 import 'package:get/get.dart';
 
 import '../../../core/sfx.dart';
@@ -89,10 +89,6 @@ class GamePage extends ConsumerWidget {
       .add({'name': name, 'score': score, 'ts': FieldValue.serverTimestamp()});
 
   /* ───────── Diálogo de fim ───────── */
-  Future<String> getPlayerName() async {
-  final prefs = await SharedPreferences.getInstance();
-  return prefs.getString('player_name') ?? 'Jogador';
-}
 
   void _showEndDialog(
       BuildContext context, WidgetRef ref, bool won, int elapsed) {

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -10,6 +10,7 @@ import 'package:get/get.dart';
 import '../../../core/progress_storage.dart';
 import '../../../core/life_manager.dart';
 import '../../../core/sfx.dart';
+import '../../../core/leaderboard_service.dart';
 
 class TangoBoardController extends GetxController {
   /// Dimensão do tabuleiro (NxN)
@@ -257,6 +258,8 @@ class TangoBoardController extends GetxController {
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(
             (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
+        LeaderboardService()
+            .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
       }
       Get.dialog(
         AlertDialog(


### PR DESCRIPTION
## Summary
- store per-phase high scores locally
- add leaderboard service to save results to Firebase
- show map total score on map page
- display map leaderboards in accordion view
- persist phase scores to leaderboards when puzzles complete
- centralize player name retrieval

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684231450a188321b7deec10862054db