### PR TITLE
Fix leaderboard flicker in expansion tiles

### DIFF
--- a/lib/app_translations.dart
+++ b/lib/app_translations.dart
@@ -66,6 +66,7 @@ class AppTranslations extends Translations {
       'portuguese': 'Portuguese',
       'english': 'English',
       'error': 'Error',
+      'error_loading': 'Error loading data',
       'phase_not_impl': 'Phase not implemented',
     },
     'pt_BR': {
@@ -131,6 +132,7 @@ class AppTranslations extends Translations {
       'portuguese': 'Português',
       'english': 'Inglês',
       'error': 'Erro',
+      'error_loading': 'Erro ao carregar',
       'phase_not_impl': 'Fase nao implementada',
     },
   };

--- a/lib/presentation/pages/general_pages/leaderboard_page.dart
+++ b/lib/presentation/pages/general_pages/leaderboard_page.dart
@@ -56,6 +56,18 @@ class LeaderboardPage extends StatelessWidget {
                 StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
                   stream: _leaders(m.id),
                   builder: (context, snap2) {
+                    if (snap2.connectionState == ConnectionState.waiting) {
+                      return ListTile(
+                        title: Text(m.id),
+                        subtitle: const LinearProgressIndicator(),
+                      );
+                    }
+                    if (snap2.hasError) {
+                      return ListTile(
+                        title: Text(m.id),
+                        subtitle: Text('error_loading'.tr),
+                      );
+                    }
                     final docs = snap2.data?.docs ?? [];
                     final first = docs.isNotEmpty ? docs.first.data() : null;
                     return ExpansionTile(
@@ -73,6 +85,12 @@ class LeaderboardPage extends StatelessWidget {
                         StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
                           stream: _phases(m.id),
                           builder: (context, phaseSnap) {
+                            if (phaseSnap.connectionState == ConnectionState.waiting) {
+                              return const Padding(
+                                padding: EdgeInsets.all(8.0),
+                                child: LinearProgressIndicator(),
+                              );
+                            }
                             final phases = phaseSnap.data?.docs ?? [];
                             return Column(
                               children: [
@@ -80,6 +98,12 @@ class LeaderboardPage extends StatelessWidget {
                                   StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
                                     stream: _phaseLeaders(m.id, p),
                                     builder: (context, phaseScoreSnap) {
+                                      if (phaseScoreSnap.connectionState == ConnectionState.waiting) {
+                                        return const Padding(
+                                          padding: EdgeInsets.symmetric(vertical: 8.0),
+                                          child: LinearProgressIndicator(),
+                                        );
+                                      }
                                       final pDocs = phaseScoreSnap.data?.docs ?? [];
                                       final pf = pDocs.isNotEmpty ? pDocs.first.data() : null;
                                       return ExpansionTile(


### PR DESCRIPTION
## Summary
- handle waiting and error states for nested leaderboard streams
- add translations for `error_loading`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684235be7f748321b45c7fae3b38b597