### PR TITLE
Sync board backgrounds with map theme

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -292,11 +292,15 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
         final data = phases.docs[i].data();
         final game = data['game'] as String? ?? 'tango';
         if (game == 'nonogram') {
-          await Get.find<NonogramBoardController>().loadPhase(widget.mapId, i);
+          final ctrl = Get.find<NonogramBoardController>();
+          ctrl.backgroundPath = _bgPath;
+          await ctrl.loadPhase(widget.mapId, i);
           Navigator.of(Get.context!, rootNavigator: true).pop(); //fechar o dialog
           await Navigator.pushNamed(Get.context!, '/nonogram');
         } else {
-          await Get.find<TangoBoardController>().loadPhase(widget.mapId, i);
+          final ctrl = Get.find<TangoBoardController>();
+          ctrl.backgroundPath = _bgPath;
+          await ctrl.loadPhase(widget.mapId, i);
           Navigator.of(Get.context!, rootNavigator: true).pop(); //fechar o dialog
           await Navigator.pushNamed(Get.context!, '/tango');
         }

--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -34,6 +34,8 @@ class NonogramBoardController extends GetxController {
   late List<List<int>> solutionMatrix;
   final RxList<List<int>> currentMatrix = <List<int>>[].obs;
 
+  String backgroundPath = 'assets/images/ui/bg_gradient.png';
+
   String? currentMapId;
   int? currentPhaseIndex;
 

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -59,9 +59,9 @@ class NonogramBoard extends GetView<NonogramBoardController> {
         ],
       ),
       body: Container(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           image: DecorationImage(
-            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            image: AssetImage(controller.backgroundPath),
             fit: BoxFit.cover,
           ),
         ),

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -42,6 +42,8 @@ class TangoBoardController extends GetxController {
   Timer? _timer;
   int _baseScore = 0;
 
+  String backgroundPath = 'assets/images/ui/bg_gradient.png';
+
   String? currentMapId;
   int? currentPhaseIndex;
 

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -63,9 +63,9 @@ class TangoBoardPage extends GetView<TangoBoardController> {
         ],
       ),
       body: Container(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           image: DecorationImage(
-            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            image: AssetImage(controller.backgroundPath),
             fit: BoxFit.cover,
           ),
         ),
@@ -151,9 +151,9 @@ class TangoBoardPage extends GetView<TangoBoardController> {
                         (constraints.maxWidth - totalSpacing) / n;
 
                     return Container(
-                      decoration: const BoxDecoration(
+                      decoration: BoxDecoration(
                         image: DecorationImage(
-                          image: AssetImage('assets/images/ui/bg_gradient.png'),
+                          image: AssetImage(controller.backgroundPath),
                           fit: BoxFit.cover,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- store customizable board background path in each board controller
- read this background when rendering board pages
- pass map background path to controller when opening a phase

## Testing
- `dart format --set-exit-if-changed lib/presentation/pages/nonogram_game/nonogram_board_controller.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423e39ccc88321b8f1ed7422ef42be