### PR TITLE
Improve board readability

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -63,6 +63,10 @@ class NonogramBoard extends GetView<NonogramBoardController> {
           image: DecorationImage(
             image: AssetImage(controller.backgroundPath),
             fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black.withOpacity(0.4),
+              BlendMode.darken,
+            ),
           ),
         ),
         child: SafeArea(

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -222,10 +222,14 @@ class GamePage extends ConsumerWidget {
       ),
       extendBodyBehindAppBar: true,
       body: Container(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           image: DecorationImage(
-            image: AssetImage('assets/images/ui/bg_gradient.png'),
+            image: const AssetImage('assets/images/ui/bg_gradient.png'),
             fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black.withOpacity(0.4),
+              BlendMode.darken,
+            ),
           ),
         ),
         child: SafeArea(

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -67,6 +67,10 @@ class TangoBoardPage extends GetView<TangoBoardController> {
           image: DecorationImage(
             image: AssetImage(controller.backgroundPath),
             fit: BoxFit.cover,
+            colorFilter: ColorFilter.mode(
+              Colors.black.withOpacity(0.4),
+              BlendMode.darken,
+            ),
           ),
         ),
         child: SafeArea(
@@ -155,6 +159,10 @@ class TangoBoardPage extends GetView<TangoBoardController> {
                         image: DecorationImage(
                           image: AssetImage(controller.backgroundPath),
                           fit: BoxFit.cover,
+                          colorFilter: ColorFilter.mode(
+                            Colors.black.withOpacity(0.4),
+                            BlendMode.darken,
+                          ),
                         ),
                       ),
                       child: Stack(


### PR DESCRIPTION
## Summary
- apply translucent dark filter to prism board background
- darken tango puzzle backgrounds
- darken nonogram puzzle background

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684240ff19c48321ae771f4414f14dcf