### PR TITLE
Show map progress and refresh list

### DIFF
--- a/lib/app_translations.dart
+++ b/lib/app_translations.dart
@@ -71,6 +71,7 @@ class AppTranslations extends Translations {
       'complete_prev_map': 'Complete 80% of the previous map to unlock.',
       'unlock_map_q': 'Watch ad to unlock this map?',
       'unlocked': 'Map unlocked!',
+      'map_progress': '@pct% completed',
     },
     'pt_BR': {
       'start_prism': 'Iniciar jogo Prism',
@@ -140,6 +141,7 @@ class AppTranslations extends Translations {
       'complete_prev_map': 'Conclua 80% do mapa anterior para desbloquear.',
       'unlock_map_q': 'Assistir anúncio para desbloquear este mapa?',
       'unlocked': 'Mapa desbloqueado!',
+      'map_progress': '@pct% concluído',
     },
   };
 }


### PR DESCRIPTION
## Summary
- convert map listing page to stateful widget
- show map completion percentage on each card
- refresh map list after returning from a map
- add translations for map progress text

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842488b1a208321adc9102a6aace791