### PR TITLE
Improve nonogram hint behavior

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -104,6 +104,7 @@ class NonogramBoardController extends GetxController {
 
   final Random _random = Random();
   final RxList<List<bool>> revealedMatrix = <List<bool>>[].obs;
+  final RxList<List<bool>> hintMatrix = <List<bool>>[].obs;
 
   @override
   void onInit() {
@@ -145,6 +146,9 @@ class NonogramBoardController extends GetxController {
 
     // Setup revealed matrix
     revealedMatrix.assignAll(
+      List.generate(size.value, (_) => List.filled(size.value, false)),
+    );
+    hintMatrix.assignAll(
       List.generate(size.value, (_) => List.filled(size.value, false)),
     );
     final initialField = board['initial'];
@@ -249,6 +253,9 @@ class NonogramBoardController extends GetxController {
         }
       }
     }
+    hintMatrix.assignAll(
+      List.generate(size.value, (_) => List.filled(size.value, false)),
+    );
     currentMatrix.refresh();
     hintsUsed.value = 0;
     clicks.value = 0;
@@ -265,7 +272,7 @@ class NonogramBoardController extends GetxController {
     final List<List<int>> available = [];
     for (int i = 0; i < size.value; i++) {
       for (int j = 0; j < size.value; j++) {
-        if (!revealedMatrix[i][j]) {
+        if (!revealedMatrix[i][j] && currentMatrix[i][j] == 0) {
           available.add([i, j]);
         }
       }
@@ -275,10 +282,12 @@ class NonogramBoardController extends GetxController {
       final r = choice[0];
       final c = choice[1];
       revealedMatrix[r][c] = true;
+      hintMatrix[r][c] = true;
       currentMatrix[r][c] = solutionMatrix[r][c];
       hintsUsed.value++;
       currentMatrix.refresh();
       revealedMatrix.refresh();
+      hintMatrix.refresh();
       _updateScore();
     }
     isLoading.value = false;

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -235,7 +235,11 @@ class NonogramBoard extends GetView<NonogramBoardController> {
                 ? controller.selectedTileColor
                 : controller.closedTileColor,
             borderRadius: BorderRadius.circular(4),
-            border: Border.all(color: Colors.grey.shade700),
+            border: Border.all(
+              color: controller.hintMatrix[row][col]
+                  ? Colors.white
+                  : Colors.grey.shade700,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- avoid revealing already opened tiles when using a hint
- track tiles revealed by hints
- show a white border around tiles revealed with hints

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842df6f0e188321bb6a388a3a6def3b