### PR TITLE
Update nnogram hints

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -106,6 +106,19 @@ class NonogramBoardController extends GetxController {
   final RxList<List<bool>> revealedMatrix = <List<bool>>[].obs;
   final RxList<List<bool>> hintMatrix = <List<bool>>[].obs;
 
+  int get hintsRemaining {
+    int count = 0;
+    for (int i = 0; i < size.value; i++) {
+      for (int j = 0; j < size.value; j++) {
+        if (!revealedMatrix[i][j] &&
+            currentMatrix[i][j] != solutionMatrix[i][j]) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
   @override
   void onInit() {
     super.onInit();
@@ -272,12 +285,14 @@ class NonogramBoardController extends GetxController {
     final List<List<int>> available = [];
     for (int i = 0; i < size.value; i++) {
       for (int j = 0; j < size.value; j++) {
-        if (!revealedMatrix[i][j] && currentMatrix[i][j] == 0) {
+        if (!revealedMatrix[i][j] &&
+            currentMatrix[i][j] != solutionMatrix[i][j]) {
           available.add([i, j]);
         }
       }
     }
-    if (available.isNotEmpty) {
+    final maxHints = size.value * size.value;
+    if (available.isNotEmpty && hintsUsed.value < maxHints) {
       final choice = available[_random.nextInt(available.length)];
       final r = choice[0];
       final c = choice[1];

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -92,10 +92,7 @@ class NonogramBoard extends GetView<NonogramBoardController> {
                 children: [
                   const SizedBox(height: 16),
                   Obx(() {
-                    final remaining = controller.revealedMatrix
-                        .expand((r) => r)
-                        .where((e) => !e)
-                        .length;
+                    final remaining = controller.hintsRemaining;
                     return Stack(
                       alignment: Alignment.center,
                       children: [


### PR DESCRIPTION
## Summary
- adjust NonogramBoard logic for hints to only correct mismatched tiles
- show remaining hint count based on mismatched tiles

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1553aec8321b0f51a25b492c9c8