### PR TITLE
Add completion check after hint in nonogram

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -304,6 +304,32 @@ class NonogramBoardController extends GetxController {
       revealedMatrix.refresh();
       hintMatrix.refresh();
       _updateScore();
+      if (_checkCompletion()) {
+        Sfx().win();
+        _stopTimer();
+        if (currentMapId != null && currentPhaseIndex != null) {
+          ProgressStorage.getInstance().then(
+              (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
+          LeaderboardService()
+              .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
+        }
+        Get.dialog(
+          AlertDialog(
+            title: Text('congrats'.tr),
+            content: Text('${'completed_puzzle'.tr}\nScore: ${score.value}'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Get.back();
+                  Get.back();
+                },
+                child: Text('ok'.tr),
+              ),
+            ],
+          ),
+          barrierDismissible: false,
+        );
+      }
     }
     isLoading.value = false;
   }


### PR DESCRIPTION
## Summary
- verify puzzle completion when revealing a hint in nonogram game

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e8eb0db4832199b981fe0a6e0b74