### PR TITLE
Fix map back button navigation

### DIFF
--- a/lib/presentation/pages/general_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/general_pages/full_mode_map_page.dart
@@ -336,7 +336,8 @@ class _FullModeMapPageState extends State<FullModeMapPage> {
         title: Text('$_mapTotal'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.pop(context),
+          onPressed: () => Navigator.of(context)
+              .popUntil(ModalRoute.withName('/full')),
         ),
         actions: const [
           Padding(


### PR DESCRIPTION
## Summary
- route the map screen's back button to the maps list

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e94f75c483219e8d7c3d8e4b8dc5