### PR TITLE
Fix map navigation by tagging map controller

### DIFF
--- a/lib/presentation/pages/map_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/map_pages/full_mode_map_page.dart
@@ -9,11 +9,11 @@ import '../../widgets/outlined_icon.dart';
 
 class FullModeMapPage extends GetView<FullModeMapController> {
   final String mapId;
-  const FullModeMapPage({super.key, required this.mapId});
+  const FullModeMapPage({super.key, required this.mapId}) : super(tag: mapId);
 
   @override
   Widget build(BuildContext context) {
-    Get.put(FullModeMapController(mapId));
+    Get.put(FullModeMapController(mapId), tag: mapId);
     return Obx(() {
       return Scaffold(
         extendBodyBehindAppBar: true,


### PR DESCRIPTION
## Summary
- ensure unique FullModeMapController instance per map by tagging it when created

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843178df8148321830f8960071758ab