### PR TITLE
Fix GetX tag initialization

### DIFF
--- a/lib/presentation/pages/map_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/map_pages/full_mode_map_page.dart
@@ -9,7 +9,9 @@ import '../../widgets/outlined_icon.dart';
 
 class FullModeMapPage extends GetView<FullModeMapController> {
   final String mapId;
-  const FullModeMapPage({super.key, required this.mapId}) : super(tag: mapId);
+  @override
+  final String? tag;
+  const FullModeMapPage({super.key, required this.mapId}) : tag = mapId;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- handle GetX tag in `FullModeMapPage` by overriding the `tag` property

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431a679f408321b5572564ca7376cc