### PR TITLE
Fix navigation and next map button

### DIFF
--- a/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
+++ b/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
@@ -80,7 +80,7 @@ class FullModeMapController extends GetxController {
   }
 
   Future<void> checkNextMap() async {
-    final match = RegExp(r'(\\d+)\$').firstMatch(mapId);
+    final match = RegExp(r'(\d+)\$').firstMatch(mapId);
     if (match == null) return;
     final nextId = 'mapa${int.parse(match.group(1)!) + 1}';
     final doc = await FirebaseFirestore.instance

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -41,7 +41,9 @@ class NonogramBoard extends GetView<NonogramBoardController> {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.pop(context);
+          Navigator.of(context).popUntil(
+            ModalRoute.withName('/full_map'),
+          );
         }
       },
       child: Scaffold(

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -167,7 +167,9 @@ class GamePage extends ConsumerWidget {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.pop(context);
+          Navigator.of(context).popUntil(
+            ModalRoute.withName('/full_map'),
+          );
         }
       },
       child: Scaffold(
@@ -209,7 +211,9 @@ class GamePage extends ConsumerWidget {
             icon: const Icon(Icons.home),
             onPressed: () async {
               if (await _confirmExit(context) && context.mounted) {
-                Navigator.pop(context);
+                Navigator.of(context).popUntil(
+                  ModalRoute.withName('/full_map'),
+                );
               }
             },
           ),

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -44,7 +44,9 @@ class TangoBoardPage extends GetView<TangoBoardController> {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.pop(context);
+          Navigator.of(context).popUntil(
+            ModalRoute.withName('/full_map'),
+          );
         }
       },
       child: Scaffold(


### PR DESCRIPTION
## Summary
- correct regex for map ID check
- ensure board pages pop to the map screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431d343fac8321a6f0d2b2dfa98172