### PR TITLE
Update map navigation

### DIFF
--- a/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
+++ b/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
@@ -106,6 +106,7 @@ class FullModeMapController extends GetxController {
       nextUnlocked.value =
           storage.isMapUnlocked(nextId) || list.length >= 8;
     }
+    await checkNextMap();
   }
 
   Future<int> phaseCount() async {

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -48,6 +48,16 @@ class NonogramBoard extends GetView<NonogramBoardController> {
       },
       child: Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () async {
+            if (await _confirmExit(context) && context.mounted) {
+              Navigator.of(context).popUntil(
+                ModalRoute.withName('/full_map'),
+              );
+            }
+          },
+        ),
         title: Text('nonogram'.tr),
         actions: [
           IconButton(

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -177,9 +177,19 @@ class GamePage extends ConsumerWidget {
         backgroundColor:
             controller.isAwaitingBomb ? Colors.orange.shade700 : Colors.transparent,
         elevation: 0,
-        leadingWidth: 104,
+        leadingWidth: 160,
         leading: Row(
           children: [
+            IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () async {
+                if (await _confirmExit(context) && context.mounted) {
+                  Navigator.of(context).popUntil(
+                    ModalRoute.withName('/full_map'),
+                  );
+                }
+              },
+            ),
             _UndoButton(
               remaining: game.undosLeft,
               onPressed: game.undosLeft == 0

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -51,6 +51,16 @@ class TangoBoardPage extends GetView<TangoBoardController> {
       },
       child: Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () async {
+            if (await _confirmExit(context) && context.mounted) {
+              Navigator.of(context).popUntil(
+                ModalRoute.withName('/full_map'),
+              );
+            }
+          },
+        ),
         title: Text('tango_puzzle'.tr),
         backgroundColor: Colors.black,
         actions: [


### PR DESCRIPTION
## Summary
- update map controller to recheck next map after completing a phase
- add explicit back navigation to the nonogram board
- add explicit back navigation to the tango board
- add a back button to the prism board

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432171fb248321a4e17624ea48e52e