### PR TITLE
Refactor Navigator usage to GetX

### DIFF
--- a/lib/presentation/pages/general_pages/home_page.dart
+++ b/lib/presentation/pages/general_pages/home_page.dart
@@ -46,7 +46,7 @@ class HomePage extends StatelessWidget {
                   color: Colors.green,
                   label: 'start_prism'.tr,
                   icon: Icons.play_arrow,
-                  onTap: () => Navigator.pushNamed(context, '/prism'),
+                  onTap: () => Get.toNamed('/prism'),
                 ),
                 // _MenuButton(
                 //   color: Colors.lightGreen,
@@ -64,25 +64,25 @@ class HomePage extends StatelessWidget {
                   color: Colors.purpleAccent,
                   label: 'start_full'.tr,
                   icon: Icons.map,
-                  onTap: () => Navigator.pushNamed(context, '/full'),
+                  onTap: () => Get.toNamed('/full'),
                 ),
                 _MenuButton(
                   color: Colors.blue,
                   label: 'leaderboards'.tr,
                   icon: Icons.bar_chart,
-                  onTap: () => Navigator.pushNamed(context, '/rank'),
+                  onTap: () => Get.toNamed('/rank'),
                 ),
                 _MenuButton(
                   color: Colors.orange,
                   label: 'settings'.tr,
                   icon: Icons.settings,
-                  onTap: () => Navigator.pushNamed(Get.context!, '/settings'),
+                  onTap: () => Get.toNamed('/settings'),
                 ),
                 _MenuButton(
                   color: Colors.cyan,
                   label: 'add_phase'.tr,
                   icon: Icons.upload_file,
-                  onTap: () => Navigator.pushNamed(Get.context!, '/add_phase'),
+                  onTap: () => Get.toNamed('/add_phase'),
                 ),
                   _MenuButton(
                   color: Colors.red,

--- a/lib/presentation/pages/map_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/map_pages/full_mode_map_page.dart
@@ -26,8 +26,9 @@ class FullModeMapPage extends GetView<FullModeMapController> {
           title: Text('${controller.mapTotal.value}'),
           leading: IconButton(
             icon: const Icon(Icons.arrow_back),
-            onPressed: () => Navigator.of(context)
-                .popUntil(ModalRoute.withName('/full')),
+            onPressed: () => Get.until(
+              (route) => route.settings.name == '/full',
+            ),
           ),
           actions: const [
             Padding(
@@ -97,14 +98,11 @@ class FullModeMapPage extends GetView<FullModeMapController> {
                             child: InkWell(
                               onTap: () async {
                                 if (controller.nextUnlocked.value) {
-                                  await Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (_) => FullModeMapPage(
-                                          mapId: controller.nextMapId.value!),
-                                      settings:
-                                          const RouteSettings(name: '/full_map'),
-                                    ),
+                                  await Get.to(
+                                    () => FullModeMapPage(
+                                        mapId: controller.nextMapId.value!),
+                                    routeName: '/full_map',
+                                    arguments: controller.nextMapId.value,
                                   );
                                 } else {
                                   final confirm = await showDialog<bool>(

--- a/lib/presentation/pages/map_pages/map_selection_page.dart
+++ b/lib/presentation/pages/map_pages/map_selection_page.dart
@@ -153,12 +153,10 @@ class _MapSelectionPageState extends State<MapSelectionPage> {
                           Get.snackbar('Ops', 'complete_prev_map'.tr,
                               snackPosition: SnackPosition.BOTTOM);
                         } else {
-                          await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => FullModeMapPage(mapId: id),
-                              settings: const RouteSettings(name: '/full_map'),
-                            ),
+                          await Get.to(
+                            () => FullModeMapPage(mapId: id),
+                            routeName: '/full_map',
+                            arguments: id,
                           );
                           if (mounted) setState(() {});
                         }

--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -41,9 +41,7 @@ class NonogramBoard extends GetView<NonogramBoardController> {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.of(context).popUntil(
-            ModalRoute.withName('/full_map'),
-          );
+          Get.until((route) => route.settings.name == '/full_map');
         }
       },
       child: Scaffold(
@@ -52,9 +50,7 @@ class NonogramBoard extends GetView<NonogramBoardController> {
           icon: const Icon(Icons.arrow_back),
           onPressed: () async {
             if (await _confirmExit(context) && context.mounted) {
-              Navigator.of(context).popUntil(
-                ModalRoute.withName('/full_map'),
-              );
+              Get.until((route) => route.settings.name == '/full_map');
             }
           },
         ),

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -167,9 +167,7 @@ class GamePage extends ConsumerWidget {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.of(context).popUntil(
-            ModalRoute.withName('/full_map'),
-          );
+          Get.until((route) => route.settings.name == '/full_map');
         }
       },
       child: Scaffold(
@@ -184,9 +182,7 @@ class GamePage extends ConsumerWidget {
               icon: const Icon(Icons.arrow_back),
               onPressed: () async {
                 if (await _confirmExit(context) && context.mounted) {
-                  Navigator.of(context).popUntil(
-                    ModalRoute.withName('/full_map'),
-                  );
+                  Get.until((route) => route.settings.name == '/full_map');
                 }
               },
             ),
@@ -221,9 +217,7 @@ class GamePage extends ConsumerWidget {
             icon: const Icon(Icons.home),
             onPressed: () async {
               if (await _confirmExit(context) && context.mounted) {
-                Navigator.of(context).popUntil(
-                  ModalRoute.withName('/full_map'),
-                );
+                Get.until((route) => route.settings.name == '/full_map');
               }
             },
           ),

--- a/lib/presentation/pages/tango_game/tango_board_page.dart
+++ b/lib/presentation/pages/tango_game/tango_board_page.dart
@@ -44,9 +44,7 @@ class TangoBoardPage extends GetView<TangoBoardController> {
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         if (await _confirmExit(context) && context.mounted) {
-          Navigator.of(context).popUntil(
-            ModalRoute.withName('/full_map'),
-          );
+          Get.until((route) => route.settings.name == '/full_map');
         }
       },
       child: Scaffold(
@@ -55,9 +53,7 @@ class TangoBoardPage extends GetView<TangoBoardController> {
           icon: const Icon(Icons.arrow_back),
           onPressed: () async {
             if (await _confirmExit(context) && context.mounted) {
-              Navigator.of(context).popUntil(
-                ModalRoute.withName('/full_map'),
-              );
+              Get.until((route) => route.settings.name == '/full_map');
             }
           },
         ),


### PR DESCRIPTION
## Summary
- use GetX navigation helpers instead of Navigator
- update map selection and map page navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684324552de883218df294b50cb87c1a