### PR TITLE
Fix map ID regex and remove unused variable

### DIFF
--- a/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
+++ b/lib/presentation/controllers/map_pages/full_mode_map_controller.dart
@@ -80,7 +80,11 @@ class FullModeMapController extends GetxController {
   }
 
   Future<void> checkNextMap() async {
-    final match = RegExp(r'(\d+)\$').firstMatch(mapId);
+    // Extract the trailing number of the current map identifier. The previous
+    // regular expression expected a literal dollar sign at the end of the
+    // string, which does not match ids like "mapa1". Using an end-of-string
+    // anchor ensures we capture the digits correctly.
+    final match = RegExp(r'(\d+)$').firstMatch(mapId);
     if (match == null) return;
     final nextId = 'mapa${int.parse(match.group(1)!) + 1}';
     final doc = await FirebaseFirestore.instance

--- a/lib/presentation/pages/map_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/map_pages/full_mode_map_page.dart
@@ -49,7 +49,6 @@ class FullModeMapPage extends GetView<FullModeMapController> {
               if (!snap.hasData) {
                 return const Center(child: CircularProgressIndicator());
               }
-              final phaseCount = snap.data!;
               return LayoutBuilder(
                 builder: (context, constraints) {
                   final points = controller.relativePoints


### PR DESCRIPTION
## Summary
- correct `checkNextMap` regex to match digits at the end of the id
- remove unused `phaseCount` variable from `FullModeMapPage`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684323efe26883218654f1c6e8cb2c8e