### PR TITLE
Refactor controller setup with GetX bindings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,10 +14,8 @@ import 'presentation/pages/general_pages/settings_page.dart';
 import 'presentation/pages/map_pages/map_selection_page.dart';
 import 'presentation/pages/map_pages/full_mode_map_page.dart';
 import 'presentation/pages/general_pages/add_phase_page.dart';
-import 'presentation/pages/tango_game/tango_board_controller.dart' show TangoBoardController;
 import 'presentation/pages/tango_game/tango_board_page.dart';
-import 'presentation/pages/nonogram_game/nonogram_board_controller.dart'
-    show NonogramBoardController;
+import 'presentation/bindings/app_bindings.dart';
 import 'presentation/pages/nonogram_game/nonogram_board_page.dart';
 import 'core/life_manager.dart';
 import 'core/sfx.dart';
@@ -53,9 +51,6 @@ class Prisma24App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 
-    Get.put(TangoBoardController());
-    Get.put(NonogramBoardController());
-
     return GetMaterialApp(
       title: 'Prisma 24',
       debugShowCheckedModeBanner: false,
@@ -83,6 +78,7 @@ class Prisma24App extends StatelessWidget {
         '/add_phase': (_) => const AddPhasePage(),
 
       },
+      initialBinding: AppBindings(),
     );
   }
 }

--- a/lib/presentation/bindings/app_bindings.dart
+++ b/lib/presentation/bindings/app_bindings.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../pages/tango_game/tango_board_controller.dart';
+import '../pages/nonogram_game/nonogram_board_controller.dart';
+
+class AppBindings extends Bindings {
+  @override
+  void dependencies() {
+    Get.put(TangoBoardController(), permanent: true);
+    Get.put(NonogramBoardController(), permanent: true);
+  }
+}

--- a/lib/presentation/bindings/full_mode_map_binding.dart
+++ b/lib/presentation/bindings/full_mode_map_binding.dart
@@ -1,0 +1,13 @@
+import 'package:get/get.dart';
+
+import '../controllers/map_pages/full_mode_map_controller.dart';
+
+class FullModeMapBinding extends Bindings {
+  final String mapId;
+  FullModeMapBinding(this.mapId);
+
+  @override
+  void dependencies() {
+    Get.put(FullModeMapController(mapId), tag: mapId);
+  }
+}

--- a/lib/presentation/pages/map_pages/full_mode_map_page.dart
+++ b/lib/presentation/pages/map_pages/full_mode_map_page.dart
@@ -6,6 +6,7 @@ import '../../controllers/map_pages/full_mode_map_controller.dart';
 import '../../widgets/lives_bar.dart';
 import '../../widgets/phase_button.dart';
 import '../../widgets/outlined_icon.dart';
+import '../../bindings/full_mode_map_binding.dart';
 
 class FullModeMapPage extends GetView<FullModeMapController> {
   final String mapId;
@@ -15,7 +16,6 @@ class FullModeMapPage extends GetView<FullModeMapController> {
 
   @override
   Widget build(BuildContext context) {
-    Get.put(FullModeMapController(mapId), tag: mapId);
     return Obx(() {
       return Scaffold(
         extendBodyBehindAppBar: true,
@@ -97,14 +97,11 @@ class FullModeMapPage extends GetView<FullModeMapController> {
                             child: InkWell(
                               onTap: () async {
                                 if (controller.nextUnlocked.value) {
-                                  await Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (_) => FullModeMapPage(
-                                          mapId: controller.nextMapId.value!),
-                                      settings:
-                                          const RouteSettings(name: '/full_map'),
-                                    ),
+                                  final id = controller.nextMapId.value!;
+                                  await Get.to(
+                                    () => FullModeMapPage(mapId: id),
+                                    binding: FullModeMapBinding(id),
+                                    routeName: '/full_map',
                                   );
                                 } else {
                                   final confirm = await showDialog<bool>(

--- a/lib/presentation/pages/map_pages/map_selection_page.dart
+++ b/lib/presentation/pages/map_pages/map_selection_page.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 
 import '../../../core/progress_storage.dart';
 import 'full_mode_map_page.dart';
+import '../../bindings/full_mode_map_binding.dart';
 
 class MapSelectionPage extends StatefulWidget {
   const MapSelectionPage({super.key});
@@ -153,12 +154,10 @@ class _MapSelectionPageState extends State<MapSelectionPage> {
                           Get.snackbar('Ops', 'complete_prev_map'.tr,
                               snackPosition: SnackPosition.BOTTOM);
                         } else {
-                          await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => FullModeMapPage(mapId: id),
-                              settings: const RouteSettings(name: '/full_map'),
-                            ),
+                          await Get.to(
+                            () => FullModeMapPage(mapId: id),
+                            binding: FullModeMapBinding(id),
+                            routeName: '/full_map',
                           );
                           if (mounted) setState(() {});
                         }


### PR DESCRIPTION
## Summary
- register global controllers using `AppBindings`
- add `FullModeMapBinding` for map pages
- use `initialBinding` in `main.dart`
- navigate to map pages via `Get.to` so bindings apply
- clean up Get.put calls from widget build methods

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432459f7f08321b7bb0cf7735521ed