### PR TITLE
Update leaderboard Firestore structure

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,14 +1,4 @@
 {
-  "indexes": [
-    {
-      "collectionGroup": "phase_scores",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {"fieldPath": "mapId", "order": "ASCENDING"},
-        {"fieldPath": "phase", "order": "ASCENDING"},
-        {"fieldPath": "score", "order": "DESCENDING"}
-      ]
-    }
-  ],
+  "indexes": [],
   "fieldOverrides": []
 }

--- a/lib/core/leaderboard_service.dart
+++ b/lib/core/leaderboard_service.dart
@@ -10,6 +10,17 @@ class LeaderboardService {
 
   final ScoreRepository _scores;
 
+  Future<int> getMinScore(String mapId, int phaseIndex) {
+    return _scores.lowestTopScore(mapId, phaseIndex);
+  }
+
+  Future<void> maybeSavePhaseScore(
+      String mapId, int phaseIndex, int score, int threshold) async {
+    if (score > threshold) {
+      await savePhaseScore(mapId, phaseIndex, score);
+    }
+  }
+
   Future<void> savePhaseScore(String mapId, int phaseIndex, int score) async {
     final name = await getPlayerName();
 
@@ -17,7 +28,5 @@ class LeaderboardService {
 
     final storage = await ProgressStorage.getInstance();
     await storage.setHighScore(mapId, phaseIndex, score);
-    final total = storage.getMapTotal(mapId);
-    await _scores.updateMapTotal(mapId, name, total);
   }
 }

--- a/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_controller.dart
@@ -39,6 +39,7 @@ class NonogramBoardController extends GetxController {
 
   String? currentMapId;
   int? currentPhaseIndex;
+  int leaderboardCutoff = 0;
 
   /// Colors used for the tiles. [closedTileColor] is for state 0 and
   /// [selectedTileColor] for state 1.
@@ -222,8 +223,8 @@ class NonogramBoardController extends GetxController {
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(
             (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
-        LeaderboardService()
-            .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
+        LeaderboardService().maybeSavePhaseScore(
+            currentMapId!, currentPhaseIndex!, score.value, leaderboardCutoff);
       }
       Get.dialog(
         AlertDialog(
@@ -311,8 +312,8 @@ class NonogramBoardController extends GetxController {
         if (currentMapId != null && currentPhaseIndex != null) {
           ProgressStorage.getInstance().then(
               (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
-          LeaderboardService()
-              .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
+          LeaderboardService().maybeSavePhaseScore(
+              currentMapId!, currentPhaseIndex!, score.value, leaderboardCutoff);
         }
         Get.dialog(
           AlertDialog(
@@ -340,6 +341,7 @@ class NonogramBoardController extends GetxController {
     isLoading.value = true;
     currentMapId = mapId;
     currentPhaseIndex = index;
+    leaderboardCutoff = await LeaderboardService().getMinScore(mapId, index);
     try {
       final data = await _repo.fetchPhase(mapId, index);
 

--- a/lib/presentation/pages/prism_game/game_page.dart
+++ b/lib/presentation/pages/prism_game/game_page.dart
@@ -83,8 +83,7 @@ class GamePage extends ConsumerWidget {
     );
   }
 
-    Future<void> saveScore(String name, int score) =>
-      ScoreRepository().savePrismScore(name, score);
+    Future<void> saveScore(String name, int score) async {}
 
   /* ───────── Diálogo de fim ───────── */
 
@@ -97,11 +96,7 @@ class GamePage extends ConsumerWidget {
       final pen    = elapsed ~/ 3;
       final total  = base + bonus - pen;
 
-      getPlayerName().then((name) {
-        if (won) {
-          saveScore(name, total);
-        }
-      });
+
 
     showDialog(
       context: context,

--- a/lib/presentation/pages/tango_game/tango_board_controller.dart
+++ b/lib/presentation/pages/tango_game/tango_board_controller.dart
@@ -48,6 +48,7 @@ class TangoBoardController extends GetxController {
 
   String? currentMapId;
   int? currentPhaseIndex;
+  int leaderboardCutoff = 0;
 
   void _startTimer() {
     _timer?.cancel();
@@ -262,8 +263,8 @@ class TangoBoardController extends GetxController {
       if (currentMapId != null && currentPhaseIndex != null) {
         ProgressStorage.getInstance().then(
             (p) => p.addCompletion(currentMapId!, currentPhaseIndex!));
-        LeaderboardService()
-            .savePhaseScore(currentMapId!, currentPhaseIndex!, score.value);
+        LeaderboardService().maybeSavePhaseScore(
+            currentMapId!, currentPhaseIndex!, score.value, leaderboardCutoff);
       }
       Get.dialog(
         AlertDialog(
@@ -314,6 +315,7 @@ void resetBoard() {
     isLoading.value = true;
     currentMapId = mapId;
     currentPhaseIndex = index;
+    leaderboardCutoff = await LeaderboardService().getMinScore(mapId, index);
     try {
       final data = await _repo.fetchPhase(mapId, index);
       if (data == null) {


### PR DESCRIPTION
## Summary
- store phase scores under `map_leaderboards/mapX/phaseX`
- keep only top three scores for each phase
- load lowest leaderboard score when a phase is started
- save the score only if it beats the lowest leaderboard entry
- display leaderboards grouped by map backgrounds
- remove previous Firestore score usages
- drop old Firestore indexes

## Testing
- `flutter format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434552b1b8832185b34871ff22d1b5