### PR TITLE
Fix missing map background field on leaderboard

### DIFF
--- a/lib/presentation/pages/general_pages/leaderboard_page.dart
+++ b/lib/presentation/pages/general_pages/leaderboard_page.dart
@@ -41,8 +41,8 @@ class LeaderboardPage extends StatelessWidget {
                   child: Stack(
                     children: [
                       Positioned.fill(
-                        child: Image.asset(
-                          _bgPath(m['bg'] as String?),
+                      child: Image.asset(
+                          _bgPath(m.data()['bg'] as String?),
                           fit: BoxFit.cover,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- avoid DocumentSnapshot errors on leaderboard when `bg` field is absent

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434889ee008321b08b1ce110fefd5e