### PR TITLE
Add dark overlay to leaderboard accordion

### DIFF
--- a/lib/presentation/pages/general_pages/leaderboard_page.dart
+++ b/lib/presentation/pages/general_pages/leaderboard_page.dart
@@ -48,13 +48,7 @@ class LeaderboardPage extends StatelessWidget {
                       ),
                       Positioned.fill(
                         child: Container(
-                          decoration: const BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [Colors.transparent, Colors.black54],
-                            ),
-                          ),
+                          color: Colors.black54,
                         ),
                       ),
                       Theme(


### PR DESCRIPTION
## Summary
- update leaderboard card with a semi-transparent black background to improve text readability

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434be1318483218fc8113e9066d030