### PR TITLE
Implement missing nonogram rules

### DIFF
--- a/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
+++ b/lib/presentation/pages/nonogram_game/nonogram_board_page.dart
@@ -161,7 +161,8 @@ class NonogramBoard extends GetView<NonogramBoardController> {
                                         width: tileSize,
                                         child: Center(
                                           child: Text(
-                                            '${controller.colCounts[c]}',
+                                            controller.colHints[c].join('\n'),
+                                            textAlign: TextAlign.center,
                                             style: const TextStyle(fontSize: 12),
                                           ),
                                         ),
@@ -176,7 +177,7 @@ class NonogramBoard extends GetView<NonogramBoardController> {
                                         height: tileSize,
                                         child: Center(
                                           child: Text(
-                                            '${controller.rowCounts[r]}',
+                                            controller.rowHints[r].join(' '),
                                             style: const TextStyle(fontSize: 12),
                                           ),
                                         ),
@@ -246,6 +247,13 @@ class NonogramBoard extends GetView<NonogramBoardController> {
                   : Colors.grey.shade700,
             ),
           ),
+          child: state == 2
+              ? const Center(
+                  child: Text(
+                  'X',
+                  style: TextStyle(color: Colors.white),
+                ))
+              : null,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- show full block sequences for row and column hints
- add third tile state and cycle on tap
- validate line hints and mark impossible cells automatically
- quick nonogram solver to check uniqueness

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684358f791c88321b8439f6531ed7be5